### PR TITLE
Fix combo box clipping

### DIFF
--- a/web/src/components/entry-dialog/DimensionComboBox.tsx
+++ b/web/src/components/entry-dialog/DimensionComboBox.tsx
@@ -31,7 +31,6 @@ const DimensionComboBox = ({ control, name, title }: DimensionComboBoxProps) => 
               <Autocomplete
                 value={value}
                 onChange={(_, value) => onChange(value)}
-                disablePortal
                 options={options}
                 renderInput={(params) => (
                   <TextField {...params} label={title} onChange={onChange} />


### PR DESCRIPTION
Combo box options list was clipped at dialog edge due to `disablePortal` attribute.