### PR TITLE
Keep IDP session alive to avoid failed GrapQL operations after some idle time

### DIFF
--- a/web/src/components/workday-browser/WorkdayList.tsx
+++ b/web/src/components/workday-browser/WorkdayList.tsx
@@ -13,6 +13,8 @@ const WorkdayList = () => {
 
   const { data } = useQuery(FindWorkdaysDocument, {
     variables: { start: start.format("YYYY-MM-DD"), end: end.format("YYYY-MM-DD") },
+    // Poll every 5 minutes, mainly to keep IDP session alive.
+    pollInterval: 5 * 60 * 1000,
   });
 
   if (!data) {


### PR DESCRIPTION
This should resolve the annoying situation where a GraphQL operation will fail after having Keijo idle for more than an hour. However, IDP session lifetime will still expire at some point leading to a similar failure which cannot be remediated by just polling.