### PR TITLE
Fix rounding errors in minute parts of durations

### DIFF
--- a/web/src/common/duration.ts
+++ b/web/src/common/duration.ts
@@ -1,0 +1,27 @@
+import { Duration } from "dayjs/plugin/duration";
+
+/**
+ * Rounds duration to minute-precision.
+ *
+ * Simply increments the minute-part of give `Duration` if the second-part is 30 or greater.
+ * In practice, this is necessary when showing durations from NV API as it stores only two
+ * decimals of the hour-based duration value. This loss of precision causes the rounded value
+ * to sometimes be a little less than a full minute leading to incorrect minute-precision
+ * duration to be shown on UI.
+ *
+ * I.e., duration 0:35 in decimal form is 0.58333... and gets saved as 0.58. When this is
+ * coverted back to duration we get 0:34:47 which `Duration.format("HH:mm")` shows as 0:34.
+ */
+export const roundToFullMinutes = (duration: Duration): Duration => {
+  // Duration does not offer methods to mutate it or create new edited durations, so we hack it.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const dur = duration as any;
+
+  if (dur.$d.seconds >= 30) {
+    dur.$d.minutes++;
+  }
+
+  dur.$d.seconds = 0;
+
+  return dur;
+};

--- a/web/src/components/entry-dialog/DurationSlider.tsx
+++ b/web/src/components/entry-dialog/DurationSlider.tsx
@@ -16,7 +16,7 @@ const DurationSlider = ({ field }: DurationSliderProps) => {
   const hoursDecimal = Number(field.value);
   const timeFieldValue = dayjs()
     .hour(hoursDecimal)
-    .minute((hoursDecimal % 1) * 60);
+    .minute(Math.round((hoursDecimal % 1) * 60));
 
   const handleTimeFieldChange = (value: Dayjs | null) => {
     if (!value) {

--- a/web/src/components/workday-accordion/EntryFlexRow.tsx
+++ b/web/src/components/workday-accordion/EntryFlexRow.tsx
@@ -1,7 +1,7 @@
 import { Box, Typography } from "@mui/material";
 import { grey } from "@mui/material/colors";
-import { Dayjs } from "dayjs";
-import useDayjs from "../../common/useDayjs";
+import dayjs, { Dayjs } from "dayjs";
+import { roundToFullMinutes } from "../../common/duration";
 import { AcceptanceStatus, Entry } from "../../graphql/generated/graphql";
 import useDarkMode from "../../theme/useDarkMode";
 import DeleteEntryButton from "./DeleteEntryButton";
@@ -18,11 +18,11 @@ type EntryFlexRowProps = {
 
 const EntryFlexRow = ({ entry, date }: EntryFlexRowProps) => {
   const { darkMode } = useDarkMode();
-  const dayjs = useDayjs();
   const { product, activity, issue, client, description } = entry;
   const accepted = entry.acceptanceStatus === AcceptanceStatus.Accepted;
   const paid = entry.acceptanceStatus === AcceptanceStatus.Paid;
   const open = entry.acceptanceStatus === AcceptanceStatus.Open;
+  const roundedDuration = roundToFullMinutes(dayjs.duration(entry.duration, "hour"));
 
   return (
     <Box
@@ -61,9 +61,7 @@ const EntryFlexRow = ({ entry, date }: EntryFlexRowProps) => {
             mr: 1,
           }}
         >
-          <Typography variant="h6">
-            {dayjs.duration(entry.duration, "hour").format("H:mm")}
-          </Typography>
+          <Typography variant="h6">{roundedDuration.format("HH:mm")}</Typography>
         </Box>
         {product && <DimensionChip dimension="product" label={product} />}
         {activity && <DimensionChip dimension="activity" label={activity} />}

--- a/web/src/components/workday-accordion/WorkdayAccordion.tsx
+++ b/web/src/components/workday-accordion/WorkdayAccordion.tsx
@@ -10,6 +10,7 @@ import {
 import { sum } from "lodash";
 import { SyntheticEvent } from "react";
 import { useTranslation } from "react-i18next";
+import { roundToFullMinutes } from "../../common/duration";
 import useDayjs from "../../common/useDayjs";
 import { Workday } from "../../graphql/generated/graphql";
 import EntryDialogButton from "../entry-dialog/EntryDialogButton";
@@ -27,7 +28,8 @@ const WorkdayAccordion = ({ workday }: WorkdayAccordionProps) => {
   const { expanded, setExpanded } = useWorkdayAccordionState(date);
 
   const totalHours = sum(workday.entries.map((wd) => wd.duration));
-  const totalHoursFormatted = dayjs.duration(totalHours, "hour").format("H:mm");
+  const totalDuration = dayjs.duration(totalHours, "hour");
+  const totalHoursFormatted = roundToFullMinutes(totalDuration).format("H:mm");
 
   const empty = workday.entries.length === 0;
 


### PR DESCRIPTION
Loss of precision by NV API caused some minute parts of durations to be shown as one less than they actually are.