### PR TITLE
Disable auto select feature in dimension combo box

### DIFF
--- a/web/src/components/entry-dialog/DimensionComboBox.tsx
+++ b/web/src/components/entry-dialog/DimensionComboBox.tsx
@@ -30,7 +30,6 @@ const DimensionComboBox = ({ form, name, title, rules }: DimensionComboBoxProps)
                 onChange={(_, value) => onChange(value)}
                 options={options}
                 autoHighlight
-                autoSelect
                 renderInput={(params) => (
                   <TextField
                     {...params}


### PR DESCRIPTION
Disabled by popular demand; auto select is too "aggressive" especially when using with mouse.