### PR TITLE
Persist user preferences in database

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 /server/dist
 /web/dist
+/web/src/graphql/generated
 /e2e/playwright-report
 /e2e/test-results
 /e2e/tests-examples

--- a/e2e/tests/entry.spec.ts
+++ b/e2e/tests/entry.spec.ts
@@ -1,12 +1,12 @@
 import { Page, expect } from "@playwright/test";
-import { test } from "../playwright.config";
 import { TFunction } from "i18next";
 import {
-  getMockProductNames,
   getMockActivityNames,
-  getMockIssueNames,
   getMockClientNames,
+  getMockIssueNames,
+  getMockProductNames,
 } from "mock-data";
+import { test } from "../playwright.config";
 
 type TestEntry = {
   product: string;
@@ -118,10 +118,15 @@ test.describe("Entry defaults", () => {
     await page.goto(emptyWeekUrl + "/create");
     await expect(page.getByRole("combobox", { name: t("entryDialog.product") })).toHaveValue("");
     await page.goto(emptyWeekUrl);
+
     await page.getByLabel(t("controls.settingsMenu")).click();
     await page.getByRole("menuitem", { name: t("controls.defaultsView") }).click();
-    await page.getByRole("combobox", { name: t("entryDialog.product") }).fill(entries[0].product);
-    await page.getByRole("combobox", { name: t("entryDialog.activity") }).fill(entries[0].activity);
+
+    await page.getByRole("combobox", { name: t("entryDialog.product") }).click();
+    await page.getByRole("option", { name: entries[0].product }).click();
+    await page.getByRole("combobox", { name: t("entryDialog.activity") }).click();
+    await page.getByRole("option", { name: entries[0].activity }).click();
+
     await page.goto(emptyWeekUrl + "/create");
     await expect(page.getByRole("combobox", { name: t("entryDialog.product") })).toHaveValue(
       entries[0].product,

--- a/e2e/tests/entry.spec.ts
+++ b/e2e/tests/entry.spec.ts
@@ -143,5 +143,8 @@ const fillEntryForm = async (page: Page, t: TFunction, entry: TestEntry) => {
   await page.getByLabel(t("entryDialog.description")).fill(entry.description);
   await page.getByLabel(t("entryDialog.duration")).pressSequentially(entry.duration);
   await page.getByRole("button", { name: /.*\d\d.*/ }).click();
-  await page.getByRole("gridcell", { name: entry.date.split(".")[0] }).click();
+  await page
+    .getByRole("gridcell", { name: entry.date.split(".")[0] })
+    .first()
+    .click();
 };

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,6 +11,7 @@ import { appGuards } from "./guards/app-guards";
 import { LoggerModule } from "./logger/logger.module";
 import { NetvisorModule } from "./netvisor/netvisor.module";
 import { SessionModule } from "./session/session.module";
+import { UserSettingsModule } from "./user-settings/user-settings.module";
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { SessionModule } from "./session/session.module";
     NetvisorModule,
     SessionModule,
     DatabaseModule,
+    UserSettingsModule,
   ],
   providers: [...appGuards],
 })

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,12 +1,12 @@
-import { ApolloDriver, ApolloDriverConfig } from "@nestjs/apollo";
+import { ApolloDriverConfig } from "@nestjs/apollo";
 import { Module } from "@nestjs/common";
 import { GraphQLModule } from "@nestjs/graphql";
 import { ServeStaticModule } from "@nestjs/serve-static";
 import { join } from "path";
 import { CacheModule } from "./cache/cache.module";
 import { ConfigModule } from "./config/config.module";
-import { ConfigService } from "./config/config.service";
 import { DatabaseModule } from "./database/database.module";
+import graphQlModuleConfig from "./graphql-module-config";
 import { appGuards } from "./guards/app-guards";
 import { LoggerModule } from "./logger/logger.module";
 import { NetvisorModule } from "./netvisor/netvisor.module";
@@ -19,14 +19,7 @@ import { UserSettingsModule } from "./user-settings/user-settings.module";
       rootPath: join(__dirname, "..", "public"),
       exclude: ["/graphql/(.*)"],
     }),
-    GraphQLModule.forRootAsync<ApolloDriverConfig>({
-      driver: ApolloDriver,
-      inject: [ConfigService],
-      useFactory: ({ config }: ConfigService) => ({
-        playground: config.inDev,
-        autoSchemaFile: true,
-      }),
-    }),
+    GraphQLModule.forRoot<ApolloDriverConfig>(graphQlModuleConfig),
     CacheModule,
     ConfigModule,
     LoggerModule,

--- a/server/src/database/migration-config.ts
+++ b/server/src/database/migration-config.ts
@@ -7,5 +7,10 @@ export default new DataSource({
   username: process.env.DATABASE_USERNAME || "postgres",
   password: process.env.DATABASE_PASSWORD || "postgres",
   database: process.env.DATABASE_NAME || "keijo_dev",
-  migrations: ["src/database/migrations/*"],
+  /**
+   * Glob pattern is used to make this work both locally and in CI as it appears that
+   * using no wildcards resolves to different paths between the two. This is arguably
+   * a little iffy but perhaps sufficient.
+   */
+  migrations: ["**/migrations/*.{js,ts}"],
 });

--- a/server/src/database/migrations/1719313985295-create-user-settings-table.ts
+++ b/server/src/database/migrations/1719313985295-create-user-settings-table.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner, Table } from "typeorm";
+
+export class CreateUserSettingsTable1719313985295 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "user_settings",
+        columns: [
+          {
+            name: "employeeNumber",
+            type: "int",
+            isPrimary: true,
+          },
+          {
+            name: "productPreset",
+            type: "varchar",
+            isNullable: true,
+          },
+          {
+            name: "activityPreset",
+            type: "varchar",
+            isNullable: true,
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(): Promise<void> {}
+}

--- a/server/src/graphql-module-config.ts
+++ b/server/src/graphql-module-config.ts
@@ -1,0 +1,19 @@
+import { ApolloServerPlugin } from "@apollo/server";
+import { ApolloServerPluginLandingPageLocalDefault } from "@apollo/server/plugin/landingPage/default";
+import { ApolloDriver, ApolloDriverConfig } from "@nestjs/apollo";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const plugins: ApolloServerPlugin<any>[] = [];
+
+if (process.env.NODE_ENV !== "production") {
+  plugins.push(ApolloServerPluginLandingPageLocalDefault({ includeCookies: true }));
+}
+
+const graphQlModuleConfig: ApolloDriverConfig = {
+  autoSchemaFile: true,
+  driver: ApolloDriver,
+  playground: false,
+  plugins,
+};
+
+export default graphQlModuleConfig;

--- a/server/src/user-settings/dto/update-settings.dto.ts
+++ b/server/src/user-settings/dto/update-settings.dto.ts
@@ -1,0 +1,10 @@
+import { Field, InputType } from "@nestjs/graphql";
+
+@InputType()
+export class UpdateSettingsDto {
+  @Field({ nullable: true })
+  productPreset?: string;
+
+  @Field({ nullable: true })
+  activityPreset?: string;
+}

--- a/server/src/user-settings/user-settings.model.ts
+++ b/server/src/user-settings/user-settings.model.ts
@@ -1,7 +1,7 @@
 import { Field, ObjectType } from "@nestjs/graphql";
 import { Column, Entity, PrimaryColumn } from "typeorm";
 
-@Entity()
+@Entity({ name: "user_settings" })
 @ObjectType()
 export class UserSettings {
   @PrimaryColumn({ update: false })

--- a/server/src/user-settings/user-settings.model.ts
+++ b/server/src/user-settings/user-settings.model.ts
@@ -1,13 +1,18 @@
+import { Field, ObjectType } from "@nestjs/graphql";
 import { Column, Entity, PrimaryColumn } from "typeorm";
 
 @Entity()
+@ObjectType()
 export class UserSettings {
   @PrimaryColumn()
+  @Field()
   employeeNumber: number;
 
   @Column({ nullable: true })
+  @Field({ nullable: true })
   productPreset: string;
 
   @Column({ nullable: true })
+  @Field({ nullable: true })
   activityPreset: string;
 }

--- a/server/src/user-settings/user-settings.model.ts
+++ b/server/src/user-settings/user-settings.model.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryColumn } from "typeorm";
+
+@Entity()
+export class UserSettings {
+  @PrimaryColumn()
+  employeeNumber: number;
+
+  @Column({ nullable: true })
+  productPreset: string;
+
+  @Column({ nullable: true })
+  activityPreset: string;
+}

--- a/server/src/user-settings/user-settings.model.ts
+++ b/server/src/user-settings/user-settings.model.ts
@@ -4,7 +4,7 @@ import { Column, Entity, PrimaryColumn } from "typeorm";
 @Entity()
 @ObjectType()
 export class UserSettings {
-  @PrimaryColumn()
+  @PrimaryColumn({ update: false })
   @Field()
   employeeNumber: number;
 

--- a/server/src/user-settings/user-settings.module.ts
+++ b/server/src/user-settings/user-settings.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { UserSettings } from "./user-settings.model";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([UserSettings])],
+  exports: [TypeOrmModule],
+})
+export class UserSettingsModule {}

--- a/server/src/user-settings/user-settings.module.ts
+++ b/server/src/user-settings/user-settings.module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { UserSettings } from "./user-settings.model";
+import { UserSettingsResolver } from "./user-settings.resolver";
 import { UserSettingsService } from "./user-settings.service";
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserSettings])],
-  providers: [UserSettingsService],
+  providers: [UserSettingsService, UserSettingsResolver],
   exports: [TypeOrmModule, UserSettingsService],
 })
 export class UserSettingsModule {}

--- a/server/src/user-settings/user-settings.module.ts
+++ b/server/src/user-settings/user-settings.module.ts
@@ -1,9 +1,11 @@
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
 import { UserSettings } from "./user-settings.model";
+import { UserSettingsService } from "./user-settings.service";
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserSettings])],
-  exports: [TypeOrmModule],
+  providers: [UserSettingsService],
+  exports: [TypeOrmModule, UserSettingsService],
 })
 export class UserSettingsModule {}

--- a/server/src/user-settings/user-settings.resolver.ts
+++ b/server/src/user-settings/user-settings.resolver.ts
@@ -1,0 +1,14 @@
+import { Query, Resolver } from "@nestjs/graphql";
+import { EmployeeNumber } from "../decorators/employee-number.decorator";
+import { UserSettings } from "./user-settings.model";
+import { UserSettingsService } from "./user-settings.service";
+
+@Resolver()
+export class UserSettingsResolver {
+  constructor(private userSettingsService: UserSettingsService) {}
+
+  @Query(() => UserSettings)
+  async getMySettings(@EmployeeNumber() employeeNumber: number) {
+    return this.userSettingsService.findOneByEmployeeNumber(employeeNumber);
+  }
+}

--- a/server/src/user-settings/user-settings.resolver.ts
+++ b/server/src/user-settings/user-settings.resolver.ts
@@ -1,5 +1,6 @@
-import { Query, Resolver } from "@nestjs/graphql";
+import { Args, Mutation, Query, Resolver } from "@nestjs/graphql";
 import { EmployeeNumber } from "../decorators/employee-number.decorator";
+import { UpdateSettingsDto } from "./dto/update-settings.dto";
 import { UserSettings } from "./user-settings.model";
 import { UserSettingsService } from "./user-settings.service";
 
@@ -10,5 +11,13 @@ export class UserSettingsResolver {
   @Query(() => UserSettings)
   async getMySettings(@EmployeeNumber() employeeNumber: number) {
     return this.userSettingsService.findOneByEmployeeNumber(employeeNumber);
+  }
+
+  @Mutation(() => UserSettings)
+  async updateSettings(
+    @EmployeeNumber() employeeNumber: number,
+    @Args("settings") update: UpdateSettingsDto,
+  ) {
+    return this.userSettingsService.update(employeeNumber, update);
   }
 }

--- a/server/src/user-settings/user-settings.service.ts
+++ b/server/src/user-settings/user-settings.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { UserSettings } from "./user-settings.model";
+
+@Injectable()
+export class UserSettingsService {
+  constructor(@InjectRepository(UserSettings) private userSettings: Repository<UserSettings>) {}
+
+  /**
+   * Find user's settings safely.
+   *
+   * User settings database entry is created if one is not found for the given
+   * employee number. This is done dynamically because Keijo does not get a
+   * user list or notifications about new users.
+   */
+  async findOneByEmployeeNumber(employeeNumber: number): Promise<UserSettings> {
+    const existing = await this.userSettings.findOneBy({ employeeNumber });
+
+    if (!existing) {
+      await this.create(employeeNumber);
+      return this.findOneByEmployeeNumber(employeeNumber);
+    }
+
+    return existing;
+  }
+
+  /**
+   * Create user settings database entry for user.
+   *
+   * This method is private because user settings should be created only by this service internally.
+   */
+  private async create(employeeNumber: number): Promise<void> {
+    await this.userSettings.save({ employeeNumber });
+  }
+}

--- a/server/src/user-settings/user-settings.service.ts
+++ b/server/src/user-settings/user-settings.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { UpdateSettingsDto } from "./dto/update-settings.dto";
 import { UserSettings } from "./user-settings.model";
 
 @Injectable()
@@ -23,6 +24,12 @@ export class UserSettingsService {
     }
 
     return existing;
+  }
+
+  async update(employeeNumber: number, settingsUpdate: UpdateSettingsDto): Promise<UserSettings> {
+    await this.userSettings.update({ employeeNumber }, settingsUpdate);
+
+    return this.findOneByEmployeeNumber(employeeNumber);
   }
 
   /**

--- a/web/src/components/defaults-dialog/DefaultsForm.tsx
+++ b/web/src/components/defaults-dialog/DefaultsForm.tsx
@@ -1,19 +1,34 @@
+import { useLazyQuery } from "@apollo/client";
 import { Grid } from "@mui/material";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { GetMySettingsDocument } from "../../graphql/generated/graphql";
 import DimensionComboBox from "../entry-dialog/DimensionComboBox";
-import { EntryFormSchema } from "../entry-dialog/useEntryForm";
 import useDefaultEntryValues from "../user-preferences/useDefaultEntryValues";
+
+type DefaultsFormSchema = {
+  activity: string;
+  product: string;
+};
 
 const DefaultsForm = () => {
   const { t } = useTranslation();
-  const { defaultEntryValues, setDefaultValues } = useDefaultEntryValues();
-  const form = useForm<Partial<EntryFormSchema>>({
-    defaultValues: defaultEntryValues || {
-      product: "",
-      activity: "",
-    },
+
+  const [getMySettings] = useLazyQuery(GetMySettingsDocument);
+
+  const getDefaultValues = async (): Promise<DefaultsFormSchema> => {
+    const { data: settingsData } = await getMySettings();
+
+    return {
+      product: settingsData?.getMySettings.productPreset || "",
+      activity: settingsData?.getMySettings.activityPreset || "",
+    };
+  };
+
+  const { setDefaultValues } = useDefaultEntryValues();
+  const form = useForm<DefaultsFormSchema>({
+    defaultValues: getDefaultValues,
   });
 
   const { watch } = form;

--- a/web/src/components/entry-dialog/DimensionComboBox.tsx
+++ b/web/src/components/entry-dialog/DimensionComboBox.tsx
@@ -30,7 +30,7 @@ const DimensionComboBox = <T extends FieldValues>({
           render={({ field: { value, onChange } }) => {
             return (
               <Autocomplete
-                value={value}
+                value={value || null}
                 onChange={(_, value) => onChange(value)}
                 options={options}
                 autoHighlight

--- a/web/src/components/entry-dialog/DurationSlider.tsx
+++ b/web/src/components/entry-dialog/DurationSlider.tsx
@@ -13,7 +13,7 @@ type DurationSliderProps = {
 const DurationSlider = ({ field }: DurationSliderProps) => {
   const { t } = useTranslation();
   const dayjs = useDayjs();
-  const hoursDecimal = Number(field.value);
+  const hoursDecimal = Number(field.value || 0);
   const timeFieldValue = dayjs()
     .hour(hoursDecimal)
     .minute(Math.round((hoursDecimal % 1) * 60));

--- a/web/src/components/entry-dialog/EntryForm.tsx
+++ b/web/src/components/entry-dialog/EntryForm.tsx
@@ -7,28 +7,28 @@ import {
   Alert,
   Box,
   Button,
+  FormControlLabel,
+  FormGroup,
   Grid,
+  Switch,
   TextField,
   useMediaQuery,
   useTheme,
-  Switch,
-  FormGroup,
-  FormControlLabel,
 } from "@mui/material";
 import { Dayjs } from "dayjs";
+import { useEffect } from "react";
 import { Controller, UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router-dom";
 import useDayjs from "../../common/useDayjs";
 import { AcceptanceStatus, Entry } from "../../graphql/generated/graphql";
+import usePreferSetRemainingHours from "../user-preferences/usePreferSetRemainingHours";
 import BigDeleteEntryButton from "./BigDeleteEntryButton";
 import DimensionComboBox from "./DimensionComboBox";
 import DurationSlider from "./DurationSlider";
 import ResponsiveDatePicker from "./ResponsiveDatePicker";
 import WorkdayHours from "./WorkdayHours";
 import useEntryForm, { EntryFormSchema } from "./useEntryForm";
-import usePreferSetRemainingHours from "../user-preferences/usePreferSetRemainingHours";
-import { useLocation, useNavigate } from "react-router-dom";
-import { useEffect } from "react";
 
 export type EntryFormProps = {
   form: UseFormReturn<EntryFormSchema>;
@@ -116,6 +116,7 @@ const EntryForm = () => {
                 render={({ field }) => (
                   <TextField
                     {...field}
+                    value={field.value || ""}
                     label={t("entryDialog.description")}
                     error={!!form.formState.errors.description}
                     helperText={form.formState.errors.description?.message}

--- a/web/src/components/entry-dialog/ResponsiveDatePicker.tsx
+++ b/web/src/components/entry-dialog/ResponsiveDatePicker.tsx
@@ -2,6 +2,7 @@ import { useMediaQuery, useTheme } from "@mui/material";
 import { DatePicker, StaticDatePicker } from "@mui/x-date-pickers-pro";
 import { ControllerRenderProps } from "react-hook-form";
 import { useTranslation } from "react-i18next";
+import useDayjs from "../../common/useDayjs";
 import { EntryFormSchema } from "./useEntryForm";
 
 type ResponsiveDatePickerProps = {
@@ -10,6 +11,7 @@ type ResponsiveDatePickerProps = {
 
 const ResponsiveDatePicker = ({ field }: ResponsiveDatePickerProps) => {
   const { t } = useTranslation();
+  const dayjs = useDayjs();
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down("md"));
 
@@ -23,6 +25,7 @@ const ResponsiveDatePicker = ({ field }: ResponsiveDatePickerProps) => {
   return (
     <StaticDatePicker
       {...rest}
+      value={rest.value || dayjs()}
       orientation="landscape"
       slots={{ actionBar: () => null }}
       localeText={{

--- a/web/src/components/entry-dialog/useEntryForm.tsx
+++ b/web/src/components/entry-dialog/useEntryForm.tsx
@@ -78,11 +78,7 @@ const useEntryForm = ({ editEntry, date }: useEntryProps) => {
   };
 
   const form = useForm<EntryFormSchema>({
-    defaultValues: async () => {
-      const asd = await getDefaultValues();
-      console.log(asd);
-      return asd;
-    },
+    defaultValues: getDefaultValues,
   });
 
   const { loading: hoursLoading } = useFormSetRemainingHours({

--- a/web/src/components/entry-dialog/useEntryForm.tsx
+++ b/web/src/components/entry-dialog/useEntryForm.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@apollo/client";
+import { useLazyQuery, useMutation } from "@apollo/client";
 import { Dayjs } from "dayjs";
 import { SubmitHandler, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -7,11 +7,11 @@ import {
   AddWorkdayEntryDocument,
   Entry,
   FindWorkdaysDocument,
+  GetMySettingsDocument,
   ReplaceWorkdayEntryDocument,
 } from "../../graphql/generated/graphql";
 import { useNotification } from "../global-notification/useNotification";
 import useFormSetRemainingHours from "./useFormSetRemainingHours";
-import useDefaultEntryValues from "../user-preferences/useDefaultEntryValues";
 
 export type EntryFormSchema = {
   date: Dayjs;
@@ -62,19 +62,28 @@ const useEntryForm = ({ editEntry, date }: useEntryProps) => {
     },
   );
 
-  const { defaultEntryValues } = useDefaultEntryValues();
+  const [getMySettings] = useLazyQuery(GetMySettingsDocument);
+  const getDefaultValues = async (): Promise<EntryFormSchema> => {
+    const { data: settingsData } = await getMySettings();
 
-  const defaultValues: EntryFormSchema = {
-    date: date ? dayjs(date) : dayjs(),
-    duration: editEntry?.duration.toString() || "",
-    description: editEntry?.description || "",
-    product: editEntry?.product || "",
-    activity: editEntry?.activity || "",
-    issue: editEntry?.issue || null,
-    client: editEntry?.client || "",
-    ...((!editEntry && defaultEntryValues) || {}),
+    return {
+      date: date ? dayjs(date) : dayjs(),
+      duration: editEntry?.duration.toString() || "",
+      description: editEntry?.description || "",
+      product: editEntry?.product || settingsData?.getMySettings.productPreset || "",
+      activity: editEntry?.activity || settingsData?.getMySettings.activityPreset || "",
+      issue: editEntry?.issue || null,
+      client: editEntry?.client || "",
+    };
   };
-  const form = useForm<EntryFormSchema>({ defaultValues });
+
+  const form = useForm<EntryFormSchema>({
+    defaultValues: async () => {
+      const asd = await getDefaultValues();
+      console.log(asd);
+      return asd;
+    },
+  });
 
   const { loading: hoursLoading } = useFormSetRemainingHours({
     form,

--- a/web/src/graphql/generated/graphql.ts
+++ b/web/src/graphql/generated/graphql.ts
@@ -66,6 +66,7 @@ export type Mutation = {
   addWorkdayEntry: Scalars['String']['output'];
   removeWorkdayEntry: Scalars['String']['output'];
   replaceWorkdayEntry: Scalars['String']['output'];
+  updateSettings: UserSettings;
 };
 
 
@@ -82,6 +83,11 @@ export type MutationRemoveWorkdayEntryArgs = {
 export type MutationReplaceWorkdayEntryArgs = {
   originalEntry: RemoveWorkdayEntryInput;
   replacementEntry: AddWorkdayEntryInput;
+};
+
+
+export type MutationUpdateSettingsArgs = {
+  settings: UpdateSettingsDto;
 };
 
 export type Query = {
@@ -105,6 +111,11 @@ export type RemoveWorkdayEntryInput = {
 export type SessionStatus = {
   __typename?: 'SessionStatus';
   employeeNumber?: Maybe<Scalars['Float']['output']>;
+};
+
+export type UpdateSettingsDto = {
+  activityPreset?: InputMaybe<Scalars['String']['input']>;
+  productPreset?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UserSettings = {
@@ -165,6 +176,13 @@ export type GetMySettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 export type GetMySettingsQuery = { __typename?: 'Query', getMySettings: { __typename?: 'UserSettings', employeeNumber: number, productPreset?: string | null, activityPreset?: string | null } };
 
+export type UpdateSettingsMutationVariables = Exact<{
+  settings: UpdateSettingsDto;
+}>;
+
+
+export type UpdateSettingsMutation = { __typename?: 'Mutation', updateSettings: { __typename?: 'UserSettings', employeeNumber: number } };
+
 
 export const AddWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"entry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"entry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"entry"}}}]}]}}]} as unknown as DocumentNode<AddWorkdayEntryMutation, AddWorkdayEntryMutationVariables>;
 export const FindDimensionOptionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindDimensionOptions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findDimensionOptions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"product"}},{"kind":"Field","name":{"kind":"Name","value":"activity"}},{"kind":"Field","name":{"kind":"Name","value":"issue"}},{"kind":"Field","name":{"kind":"Name","value":"client"}}]}}]}}]} as unknown as DocumentNode<FindDimensionOptionsQuery, FindDimensionOptionsQueryVariables>;
@@ -173,3 +191,4 @@ export const GetSessionStatusDocument = {"kind":"Document","definitions":[{"kind
 export const RemoveWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"entry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RemoveWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"entry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"entry"}}}]}]}}]} as unknown as DocumentNode<RemoveWorkdayEntryMutation, RemoveWorkdayEntryMutationVariables>;
 export const ReplaceWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ReplaceWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"originalEntry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RemoveWorkdayEntryInput"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"replacementEntry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"replaceWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"originalEntry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"originalEntry"}}},{"kind":"Argument","name":{"kind":"Name","value":"replacementEntry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"replacementEntry"}}}]}]}}]} as unknown as DocumentNode<ReplaceWorkdayEntryMutation, ReplaceWorkdayEntryMutationVariables>;
 export const GetMySettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMySettings"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getMySettings"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"employeeNumber"}},{"kind":"Field","name":{"kind":"Name","value":"productPreset"}},{"kind":"Field","name":{"kind":"Name","value":"activityPreset"}}]}}]}}]} as unknown as DocumentNode<GetMySettingsQuery, GetMySettingsQueryVariables>;
+export const UpdateSettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateSettings"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"settings"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateSettingsDto"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"updateSettings"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"settings"},"value":{"kind":"Variable","name":{"kind":"Name","value":"settings"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"employeeNumber"}}]}}]}}]} as unknown as DocumentNode<UpdateSettingsMutation, UpdateSettingsMutationVariables>;

--- a/web/src/graphql/generated/graphql.ts
+++ b/web/src/graphql/generated/graphql.ts
@@ -1,84 +1,83 @@
-import { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
-  [_ in K]?: never;
-};
-export type Incremental<T> =
-  | T
-  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  DateTime: { input: any; output: any };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: any; output: any; }
 };
 
 export enum AcceptanceStatus {
-  Accepted = "Accepted",
-  Checked = "Checked",
-  Open = "Open",
-  Paid = "Paid",
+  Accepted = 'Accepted',
+  Checked = 'Checked',
+  Open = 'Open',
+  Paid = 'Paid'
 }
 
 export type AddWorkdayEntryInput = {
-  activity?: InputMaybe<Scalars["String"]["input"]>;
-  client?: InputMaybe<Scalars["String"]["input"]>;
-  date: Scalars["DateTime"]["input"];
-  description: Scalars["String"]["input"];
-  duration: Scalars["Float"]["input"];
-  issue?: InputMaybe<Scalars["String"]["input"]>;
-  product?: InputMaybe<Scalars["String"]["input"]>;
+  activity?: InputMaybe<Scalars['String']['input']>;
+  client?: InputMaybe<Scalars['String']['input']>;
+  date: Scalars['DateTime']['input'];
+  description: Scalars['String']['input'];
+  duration: Scalars['Float']['input'];
+  issue?: InputMaybe<Scalars['String']['input']>;
+  product?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type DimensionOptions = {
-  __typename?: "DimensionOptions";
-  activity: Array<Scalars["String"]["output"]>;
-  client: Array<Scalars["String"]["output"]>;
-  issue: Array<Scalars["String"]["output"]>;
-  product: Array<Scalars["String"]["output"]>;
+  __typename?: 'DimensionOptions';
+  activity: Array<Scalars['String']['output']>;
+  client: Array<Scalars['String']['output']>;
+  issue: Array<Scalars['String']['output']>;
+  product: Array<Scalars['String']['output']>;
 };
 
 export type Entry = {
-  __typename?: "Entry";
+  __typename?: 'Entry';
   acceptanceStatus: AcceptanceStatus;
-  activity?: Maybe<Scalars["String"]["output"]>;
-  client?: Maybe<Scalars["String"]["output"]>;
-  description: Scalars["String"]["output"];
-  duration: Scalars["Float"]["output"];
-  durationInHours: Scalars["Boolean"]["output"];
-  issue?: Maybe<Scalars["String"]["output"]>;
-  key: Scalars["String"]["output"];
-  product?: Maybe<Scalars["String"]["output"]>;
-  ratioNumber?: Maybe<Scalars["Float"]["output"]>;
-  typeName: Scalars["String"]["output"];
+  activity?: Maybe<Scalars['String']['output']>;
+  client?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  duration: Scalars['Float']['output'];
+  durationInHours: Scalars['Boolean']['output'];
+  issue?: Maybe<Scalars['String']['output']>;
+  key: Scalars['String']['output'];
+  product?: Maybe<Scalars['String']['output']>;
+  ratioNumber?: Maybe<Scalars['Float']['output']>;
+  typeName: Scalars['String']['output'];
 };
 
 export type FindWorkdaysInput = {
-  end: Scalars["DateTime"]["input"];
-  start: Scalars["DateTime"]["input"];
+  end: Scalars['DateTime']['input'];
+  start: Scalars['DateTime']['input'];
 };
 
 export type Mutation = {
-  __typename?: "Mutation";
-  addWorkdayEntry: Scalars["String"]["output"];
-  removeWorkdayEntry: Scalars["String"]["output"];
-  replaceWorkdayEntry: Scalars["String"]["output"];
+  __typename?: 'Mutation';
+  addWorkdayEntry: Scalars['String']['output'];
+  removeWorkdayEntry: Scalars['String']['output'];
+  replaceWorkdayEntry: Scalars['String']['output'];
 };
+
 
 export type MutationAddWorkdayEntryArgs = {
   entry: AddWorkdayEntryInput;
 };
 
+
 export type MutationRemoveWorkdayEntryArgs = {
   entry: RemoveWorkdayEntryInput;
 };
+
 
 export type MutationReplaceWorkdayEntryArgs = {
   originalEntry: RemoveWorkdayEntryInput;
@@ -86,29 +85,38 @@ export type MutationReplaceWorkdayEntryArgs = {
 };
 
 export type Query = {
-  __typename?: "Query";
+  __typename?: 'Query';
   findDimensionOptions: DimensionOptions;
   findWorkdays: Array<Workday>;
+  getMySettings: UserSettings;
   getSessionStatus: SessionStatus;
 };
+
 
 export type QueryFindWorkdaysArgs = {
   query: FindWorkdaysInput;
 };
 
 export type RemoveWorkdayEntryInput = {
-  date: Scalars["DateTime"]["input"];
-  key: Scalars["String"]["input"];
+  date: Scalars['DateTime']['input'];
+  key: Scalars['String']['input'];
 };
 
 export type SessionStatus = {
-  __typename?: "SessionStatus";
-  employeeNumber?: Maybe<Scalars["Float"]["output"]>;
+  __typename?: 'SessionStatus';
+  employeeNumber?: Maybe<Scalars['Float']['output']>;
+};
+
+export type UserSettings = {
+  __typename?: 'UserSettings';
+  activityPreset?: Maybe<Scalars['String']['output']>;
+  employeeNumber: Scalars['Float']['output'];
+  productPreset?: Maybe<Scalars['String']['output']>;
 };
 
 export type Workday = {
-  __typename?: "Workday";
-  date: Scalars["DateTime"]["output"];
+  __typename?: 'Workday';
+  date: Scalars['DateTime']['output'];
   entries: Array<Entry>;
 };
 
@@ -116,321 +124,52 @@ export type AddWorkdayEntryMutationVariables = Exact<{
   entry: AddWorkdayEntryInput;
 }>;
 
-export type AddWorkdayEntryMutation = { __typename?: "Mutation"; addWorkdayEntry: string };
 
-export type FindDimensionOptionsQueryVariables = Exact<{ [key: string]: never }>;
+export type AddWorkdayEntryMutation = { __typename?: 'Mutation', addWorkdayEntry: string };
 
-export type FindDimensionOptionsQuery = {
-  __typename?: "Query";
-  findDimensionOptions: {
-    __typename?: "DimensionOptions";
-    product: Array<string>;
-    activity: Array<string>;
-    issue: Array<string>;
-    client: Array<string>;
-  };
-};
+export type FindDimensionOptionsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type FindDimensionOptionsQuery = { __typename?: 'Query', findDimensionOptions: { __typename?: 'DimensionOptions', product: Array<string>, activity: Array<string>, issue: Array<string>, client: Array<string> } };
 
 export type FindWorkdaysQueryVariables = Exact<{
-  start: Scalars["DateTime"]["input"];
-  end: Scalars["DateTime"]["input"];
+  start: Scalars['DateTime']['input'];
+  end: Scalars['DateTime']['input'];
 }>;
 
-export type FindWorkdaysQuery = {
-  __typename?: "Query";
-  findWorkdays: Array<{
-    __typename?: "Workday";
-    date: any;
-    entries: Array<{
-      __typename?: "Entry";
-      key: string;
-      duration: number;
-      durationInHours: boolean;
-      description: string;
-      acceptanceStatus: AcceptanceStatus;
-      typeName: string;
-      ratioNumber?: number | null;
-      product?: string | null;
-      activity?: string | null;
-      issue?: string | null;
-      client?: string | null;
-    }>;
-  }>;
-};
 
-export type GetSessionStatusQueryVariables = Exact<{ [key: string]: never }>;
+export type FindWorkdaysQuery = { __typename?: 'Query', findWorkdays: Array<{ __typename?: 'Workday', date: any, entries: Array<{ __typename?: 'Entry', key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: AcceptanceStatus, typeName: string, ratioNumber?: number | null, product?: string | null, activity?: string | null, issue?: string | null, client?: string | null }> }> };
 
-export type GetSessionStatusQuery = {
-  __typename?: "Query";
-  getSessionStatus: { __typename?: "SessionStatus"; employeeNumber?: number | null };
-};
+export type GetSessionStatusQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetSessionStatusQuery = { __typename?: 'Query', getSessionStatus: { __typename?: 'SessionStatus', employeeNumber?: number | null } };
 
 export type RemoveWorkdayEntryMutationVariables = Exact<{
   entry: RemoveWorkdayEntryInput;
 }>;
 
-export type RemoveWorkdayEntryMutation = { __typename?: "Mutation"; removeWorkdayEntry: string };
+
+export type RemoveWorkdayEntryMutation = { __typename?: 'Mutation', removeWorkdayEntry: string };
 
 export type ReplaceWorkdayEntryMutationVariables = Exact<{
   originalEntry: RemoveWorkdayEntryInput;
   replacementEntry: AddWorkdayEntryInput;
 }>;
 
-export type ReplaceWorkdayEntryMutation = { __typename?: "Mutation"; replaceWorkdayEntry: string };
 
-export const AddWorkdayEntryDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "AddWorkdayEntry" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "entry" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "AddWorkdayEntryInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "addWorkdayEntry" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "entry" },
-                value: { kind: "Variable", name: { kind: "Name", value: "entry" } },
-              },
-            ],
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<AddWorkdayEntryMutation, AddWorkdayEntryMutationVariables>;
-export const FindDimensionOptionsDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "FindDimensionOptions" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "findDimensionOptions" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "Field", name: { kind: "Name", value: "product" } },
-                { kind: "Field", name: { kind: "Name", value: "activity" } },
-                { kind: "Field", name: { kind: "Name", value: "issue" } },
-                { kind: "Field", name: { kind: "Name", value: "client" } },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<FindDimensionOptionsQuery, FindDimensionOptionsQueryVariables>;
-export const FindWorkdaysDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "FindWorkdays" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "start" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "DateTime" } },
-          },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "end" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "DateTime" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "findWorkdays" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "query" },
-                value: {
-                  kind: "ObjectValue",
-                  fields: [
-                    {
-                      kind: "ObjectField",
-                      name: { kind: "Name", value: "start" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "start" } },
-                    },
-                    {
-                      kind: "ObjectField",
-                      name: { kind: "Name", value: "end" },
-                      value: { kind: "Variable", name: { kind: "Name", value: "end" } },
-                    },
-                  ],
-                },
-              },
-            ],
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [
-                { kind: "Field", name: { kind: "Name", value: "date" } },
-                {
-                  kind: "Field",
-                  name: { kind: "Name", value: "entries" },
-                  selectionSet: {
-                    kind: "SelectionSet",
-                    selections: [
-                      { kind: "Field", name: { kind: "Name", value: "key" } },
-                      { kind: "Field", name: { kind: "Name", value: "duration" } },
-                      { kind: "Field", name: { kind: "Name", value: "durationInHours" } },
-                      { kind: "Field", name: { kind: "Name", value: "description" } },
-                      { kind: "Field", name: { kind: "Name", value: "acceptanceStatus" } },
-                      { kind: "Field", name: { kind: "Name", value: "typeName" } },
-                      { kind: "Field", name: { kind: "Name", value: "ratioNumber" } },
-                      { kind: "Field", name: { kind: "Name", value: "product" } },
-                      { kind: "Field", name: { kind: "Name", value: "activity" } },
-                      { kind: "Field", name: { kind: "Name", value: "issue" } },
-                      { kind: "Field", name: { kind: "Name", value: "client" } },
-                    ],
-                  },
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<FindWorkdaysQuery, FindWorkdaysQueryVariables>;
-export const GetSessionStatusDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "query",
-      name: { kind: "Name", value: "GetSessionStatus" },
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "getSessionStatus" },
-            selectionSet: {
-              kind: "SelectionSet",
-              selections: [{ kind: "Field", name: { kind: "Name", value: "employeeNumber" } }],
-            },
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<GetSessionStatusQuery, GetSessionStatusQueryVariables>;
-export const RemoveWorkdayEntryDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "RemoveWorkdayEntry" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "entry" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "RemoveWorkdayEntryInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "removeWorkdayEntry" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "entry" },
-                value: { kind: "Variable", name: { kind: "Name", value: "entry" } },
-              },
-            ],
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<RemoveWorkdayEntryMutation, RemoveWorkdayEntryMutationVariables>;
-export const ReplaceWorkdayEntryDocument = {
-  kind: "Document",
-  definitions: [
-    {
-      kind: "OperationDefinition",
-      operation: "mutation",
-      name: { kind: "Name", value: "ReplaceWorkdayEntry" },
-      variableDefinitions: [
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "originalEntry" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "RemoveWorkdayEntryInput" } },
-          },
-        },
-        {
-          kind: "VariableDefinition",
-          variable: { kind: "Variable", name: { kind: "Name", value: "replacementEntry" } },
-          type: {
-            kind: "NonNullType",
-            type: { kind: "NamedType", name: { kind: "Name", value: "AddWorkdayEntryInput" } },
-          },
-        },
-      ],
-      selectionSet: {
-        kind: "SelectionSet",
-        selections: [
-          {
-            kind: "Field",
-            name: { kind: "Name", value: "replaceWorkdayEntry" },
-            arguments: [
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "originalEntry" },
-                value: { kind: "Variable", name: { kind: "Name", value: "originalEntry" } },
-              },
-              {
-                kind: "Argument",
-                name: { kind: "Name", value: "replacementEntry" },
-                value: { kind: "Variable", name: { kind: "Name", value: "replacementEntry" } },
-              },
-            ],
-          },
-        ],
-      },
-    },
-  ],
-} as unknown as DocumentNode<ReplaceWorkdayEntryMutation, ReplaceWorkdayEntryMutationVariables>;
+export type ReplaceWorkdayEntryMutation = { __typename?: 'Mutation', replaceWorkdayEntry: string };
+
+export type GetMySettingsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetMySettingsQuery = { __typename?: 'Query', getMySettings: { __typename?: 'UserSettings', employeeNumber: number, productPreset?: string | null, activityPreset?: string | null } };
+
+
+export const AddWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"entry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"entry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"entry"}}}]}]}}]} as unknown as DocumentNode<AddWorkdayEntryMutation, AddWorkdayEntryMutationVariables>;
+export const FindDimensionOptionsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindDimensionOptions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findDimensionOptions"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"product"}},{"kind":"Field","name":{"kind":"Name","value":"activity"}},{"kind":"Field","name":{"kind":"Name","value":"issue"}},{"kind":"Field","name":{"kind":"Name","value":"client"}}]}}]}}]} as unknown as DocumentNode<FindDimensionOptionsQuery, FindDimensionOptionsQueryVariables>;
+export const FindWorkdaysDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"FindWorkdays"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"start"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"end"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"DateTime"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"findWorkdays"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"query"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"start"},"value":{"kind":"Variable","name":{"kind":"Name","value":"start"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"end"},"value":{"kind":"Variable","name":{"kind":"Name","value":"end"}}}]}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"date"}},{"kind":"Field","name":{"kind":"Name","value":"entries"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"key"}},{"kind":"Field","name":{"kind":"Name","value":"duration"}},{"kind":"Field","name":{"kind":"Name","value":"durationInHours"}},{"kind":"Field","name":{"kind":"Name","value":"description"}},{"kind":"Field","name":{"kind":"Name","value":"acceptanceStatus"}},{"kind":"Field","name":{"kind":"Name","value":"typeName"}},{"kind":"Field","name":{"kind":"Name","value":"ratioNumber"}},{"kind":"Field","name":{"kind":"Name","value":"product"}},{"kind":"Field","name":{"kind":"Name","value":"activity"}},{"kind":"Field","name":{"kind":"Name","value":"issue"}},{"kind":"Field","name":{"kind":"Name","value":"client"}}]}}]}}]}}]} as unknown as DocumentNode<FindWorkdaysQuery, FindWorkdaysQueryVariables>;
+export const GetSessionStatusDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetSessionStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getSessionStatus"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"employeeNumber"}}]}}]}}]} as unknown as DocumentNode<GetSessionStatusQuery, GetSessionStatusQueryVariables>;
+export const RemoveWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RemoveWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"entry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RemoveWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"removeWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"entry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"entry"}}}]}]}}]} as unknown as DocumentNode<RemoveWorkdayEntryMutation, RemoveWorkdayEntryMutationVariables>;
+export const ReplaceWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"ReplaceWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"originalEntry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"RemoveWorkdayEntryInput"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"replacementEntry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"replaceWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"originalEntry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"originalEntry"}}},{"kind":"Argument","name":{"kind":"Name","value":"replacementEntry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"replacementEntry"}}}]}]}}]} as unknown as DocumentNode<ReplaceWorkdayEntryMutation, ReplaceWorkdayEntryMutationVariables>;
+export const GetMySettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetMySettings"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"getMySettings"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"employeeNumber"}},{"kind":"Field","name":{"kind":"Name","value":"productPreset"}},{"kind":"Field","name":{"kind":"Name","value":"activityPreset"}}]}}]}}]} as unknown as DocumentNode<GetMySettingsQuery, GetMySettingsQueryVariables>;

--- a/web/src/graphql/user-settings.graphql
+++ b/web/src/graphql/user-settings.graphql
@@ -1,0 +1,7 @@
+query GetMySettings {
+  getMySettings {
+    employeeNumber
+    productPreset
+    activityPreset
+  }
+}

--- a/web/src/graphql/user-settings.graphql
+++ b/web/src/graphql/user-settings.graphql
@@ -5,3 +5,9 @@ query GetMySettings {
     activityPreset
   }
 }
+
+mutation UpdateSettings($settings: UpdateSettingsDto!) {
+  updateSettings(settings: $settings) {
+    employeeNumber
+  }
+}


### PR DESCRIPTION
- New `UserSettingsModule` with a service and a resolver for persisting user-specific preferences in database.
- `useEntryForm` and `DefaultsForm` updated to use preferences from database.

~Draft status because I'm thinking about adding some refactoring.~ I will do the refactoring in a later PR to not bloat this one any more.