### PR TITLE
Jira recent issues

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -107,6 +107,12 @@ const en = {
   titles: {
     workdayBrowser: "Entries",
   },
+  jira: {
+    issueGroups: {
+      all: "All",
+      recent: "Recent",
+    },
+  },
 };
 
 export default en;

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -107,6 +107,12 @@ const fi = {
   titles: {
     workdayBrowser: "Työaikakirjaukset",
   },
+  jira: {
+    issueGroups: {
+      all: "Kaikki",
+      recent: "Viimeaikaiset",
+    },
+  },
 };
 
 export default fi;

--- a/web/src/jira/components/JiraIssueComboBox.tsx
+++ b/web/src/jira/components/JiraIssueComboBox.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from "react";
 import { useJiraIssueOptions } from "./useJiraIssueOptions";
 import { useNotificationState } from "../../components/global-notification/useNotification";
 import { queryClient } from "../queryClient";
+import { t } from "i18next";
 
 type JiraIssueComboBoxProps<T extends FieldValues> = {
   form: UseFormReturn<T>;
@@ -92,6 +93,14 @@ const JiraIssueComboBox = <T extends FieldValues>({
             ? [...options, { label: "Loading", type: "loader", text: "Loading..." }]
             : options;
         },
+        groupBy: searchFilter
+          ? undefined
+          : (option) => {
+              if (option.type === "recent") {
+                return t("jira.issueGroups.recent");
+              }
+              return t("jira.issueGroups.all");
+            },
         ListboxProps: {
           ref: rootRef,
         },

--- a/web/src/jira/components/useJiraIssueOptions.ts
+++ b/web/src/jira/components/useJiraIssueOptions.ts
@@ -79,7 +79,7 @@ export const useJiraIssueOptions = ({
   const { data: recentIssueData } = useRecentIssues();
   const recentIssueOptions = (recentIssueData?.issues || [])
     .filter((issue) => issueKeys.includes(issue.key))
-    .slice(0, 5)
+    .slice(0, 10)
     .map((issue) => ({
       label: issue.key,
       text: `${issue.key}: ${issue.fields.summary}`,

--- a/web/src/jira/components/useJiraIssueOptions.ts
+++ b/web/src/jira/components/useJiraIssueOptions.ts
@@ -94,7 +94,9 @@ export const useJiraIssueOptions = ({
   const options =
     pageError || searchError
       ? issueKeys.map((key) => ({ label: key, text: key }))
-      : [...recentIssueOptions, ...pagedOptions];
+      : searchFilter
+        ? pagedOptions
+        : [...recentIssueOptions, ...pagedOptions];
 
   const loadMore = useCallback(async () => {
     if (hasNextPage) {

--- a/web/src/jira/components/useJiraIssueOptions.ts
+++ b/web/src/jira/components/useJiraIssueOptions.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 
-import { useGetIssues, useSearchIssues } from "../jiraApi";
+import { useGetIssues, useRecentIssues, useSearchIssues } from "../jiraApi";
 import { chunkArray, mergePages } from "../jiraUtils";
 import { jiraQueryMaxResults } from "../jiraConfig";
 
@@ -76,13 +76,25 @@ export const useJiraIssueOptions = ({
     return searchIssues;
   }, [filteredOptions, issueKeys, searchedIssueData?.pages]);
 
+  const { data: recentIssueData } = useRecentIssues();
+  const recentIssueOptions = (recentIssueData?.issues || [])
+    .filter((issue) => issueKeys.includes(issue.key))
+    .slice(0, 5)
+    .map((issue) => ({
+      label: issue.key,
+      text: `${issue.key}: ${issue.fields.summary}`,
+      type: "recent",
+    }));
+
   const pagedOptions = mergePages(
     chunkArray(filteredOptions, jiraQueryMaxResults),
     chunkArray(searchOptions, jiraQueryMaxResults),
   ).flat();
 
   const options =
-    pageError || searchError ? issueKeys.map((key) => ({ label: key, text: key })) : pagedOptions;
+    pageError || searchError
+      ? issueKeys.map((key) => ({ label: key, text: key }))
+      : [...recentIssueOptions, ...pagedOptions];
 
   const loadMore = useCallback(async () => {
     if (hasNextPage) {

--- a/web/src/jira/jiraApi.ts
+++ b/web/src/jira/jiraApi.ts
@@ -5,6 +5,7 @@ import {
   UseInfiniteQueryOptions,
   InfiniteData,
   QueryKey,
+  UseQueryOptions,
 } from "@tanstack/react-query";
 import { axiosJira, axiosKeijo } from "./axiosInstance";
 import { jiraQueryMaxResults } from "./jiraConfig";
@@ -16,10 +17,7 @@ export type JiraIssueResult = {
   total: number;
 };
 
-type UseGetIssuesProps = {
-  issueKeys: Array<string>;
-  enabled?: boolean;
-} & Partial<
+type InfiniteIssueOptions = Partial<
   UseInfiniteQueryOptions<
     JiraIssueResult,
     Error,
@@ -30,19 +28,15 @@ type UseGetIssuesProps = {
   >
 >;
 
+type UseGetIssuesProps = {
+  issueKeys: Array<string>;
+  enabled?: boolean;
+} & InfiniteIssueOptions;
+
 type UseSearchIssuesProps = {
   issueKeys: Array<string>;
   searchFilter: string;
-} & Partial<
-  UseInfiniteQueryOptions<
-    JiraIssueResult,
-    Error,
-    InfiniteData<JiraIssueResult, number>,
-    JiraIssueResult,
-    QueryKey,
-    number
-  >
->;
+} & InfiniteIssueOptions;
 
 const getAccessToken = async () => {
   const token = (await axiosKeijo.get("/access-token")).data;
@@ -168,3 +162,18 @@ export const useSearchIssues = ({
     ...query,
   };
 };
+
+/**
+ * Get users recent issues
+ */
+export const useRecentIssues = (
+  queryProps?: Partial<UseQueryOptions<JiraIssueResult>>,
+): UseQueryResult<JiraIssueResult> =>
+  useQuery({
+    queryKey: ["recentIssues"],
+    queryFn: async () => {
+      return await getIssues(`issuekey in issueHistory() order by lastViewed DESC`);
+    },
+    retry: 2,
+    ...queryProps,
+  });

--- a/web/src/jira/jiraApi.ts
+++ b/web/src/jira/jiraApi.ts
@@ -10,7 +10,7 @@ import {
 import { axiosJira, axiosKeijo } from "./axiosInstance";
 import { jiraQueryMaxResults } from "./jiraConfig";
 import { findKeysIncludingWord, findWordInKeys, removeWord } from "./jiraUtils";
-import { jqlAND, jqlOR, jqlOrderBy, keyIsInKeys, summaryContains } from "./jql";
+import { jqlAND, jqlOR, jqlOrderBy, jqlRecentIssues, keyIsInKeys, summaryContains } from "./jql";
 
 export type JiraIssueResult = {
   issues: Array<{ key: string; fields: { summary: string } }>;
@@ -172,7 +172,7 @@ export const useRecentIssues = (
   useQuery({
     queryKey: ["recentIssues"],
     queryFn: async () => {
-      return await getIssues(`issuekey in issueHistory() order by lastViewed DESC`);
+      return await getIssues(jqlOrderBy(jqlRecentIssues(), "lastViewed", "DESC"));
     },
     retry: 2,
     ...queryProps,

--- a/web/src/jira/jql.ts
+++ b/web/src/jira/jql.ts
@@ -2,10 +2,13 @@ export const jqlAND = (jqlFirst: string, jqlSecond: string) => `(${jqlFirst}) AN
 
 export const jqlOR = (jqlFirst: string, jqlSecond: string) => `(${jqlFirst}) OR (${jqlSecond})`;
 
+export const jqlOrderBy = (jql: string, field: string, order: "DESC" | "ASC" = "DESC") =>
+  `${jql} ORDER BY ${field} ${order}`;
+
 export const keyIsInKeys = (issueKeys: string[]) =>
   `key in (${issueKeys.map((key) => `'${key}'`).join(", ")})`;
 
 export const summaryContains = (searchFilter: string) => `summary ~ '${searchFilter.trim()}*'`;
 
-export const jqlOrderBy = (jql: string, field: string, order: "DESC" | "ASC" = "DESC") =>
-  `${jql} ORDER BY ${field} ${order}`;
+export const jqlRecentIssues = () =>
+  "issuekey in issueHistory() OR assignee = currentUser() OR reporter = currentUser()";


### PR DESCRIPTION
Show issues recently interacted with in issue dropdown options under _Recent_ group. This could be done also by merging branch [jira-fetch-logic](https://github.com/funidata/keijo/tree/jira-fetch-logic)  which fetches all issues in one query and sorts them to show latest issues interacted with.