### PR TITLE
Execute database migrations from Dockerfile for production-like environments

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -71,8 +71,6 @@ jobs:
           path: /tmp
       - name: Load image
         run: docker load --input /tmp/keijo.tar
-      - name: Run database migrations
-        run: docker compose -f compose.ci.yaml run --entrypoint npx server typeorm migration:run -d dist/database/migration-config.js
       - name: Start backend
         run: docker compose -f compose.ci.yaml up -d server
       - name: Wait for backend

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -30,4 +30,5 @@ COPY --from=build /usr/src/app/dist ./dist
 COPY --from=build /usr/src/app/node_modules ./node_modules
 COPY --from=build /usr/src/web/dist ./public
 
-ENTRYPOINT ["node", "dist/main.js"]
+# Run database migrations before booting server.
+CMD npx typeorm migration:run -d dist/database/migration-config.js && node dist/main.js


### PR DESCRIPTION
Implements a suggestion from infrastructure team that migrations be run on container start-up rather than in a separate deploy step.