### PR TITLE
Fix set remaining hours option on current day

### DIFF
--- a/web/src/components/entry-dialog/useEntryForm.tsx
+++ b/web/src/components/entry-dialog/useEntryForm.tsx
@@ -83,7 +83,7 @@ const useEntryForm = ({ editEntry, date }: useEntryProps) => {
 
   const { loading: hoursLoading } = useFormSetRemainingHours({
     form,
-    isEnabled: editEntry === undefined,
+    isEnabled: editEntry === undefined && !form.formState.isLoading,
   });
 
   const addWorkday: SubmitHandler<EntryFormSchema> = async (formValues) => {


### PR DESCRIPTION
Fixes a bug where remaining hours were not set on current day form even if enabled