### PR TITLE
Apply SSL configuration to express-session's database connection

### DIFF
--- a/server/src/jira/session-setup.ts
+++ b/server/src/jira/session-setup.ts
@@ -1,20 +1,21 @@
-import session from "express-session";
 import pgSession from "connect-pg-simple";
+import expressSession from "express-session";
 import pg from "pg";
 import { ConfigService } from "../config/config.service";
 
 export function createSession(configService: ConfigService) {
-  const { username, password, host, port, name } = configService.config.database;
+  const { username, password, host, port, name, ssl } = configService.config.database;
   const pgPool = new pg.Pool({
     database: name,
     user: username,
     password,
     host,
     port,
+    ssl: ssl ? { rejectUnauthorized: false } : false,
   });
 
-  return session({
-    store: new (pgSession(session))({
+  return expressSession({
+    store: new (pgSession(expressSession))({
       pool: pgPool,
       createTableIfMissing: configService.config.inDev,
     }),

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -2,11 +2,11 @@ import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { useContainer } from "class-validator";
+import cookieParser from "cookie-parser";
 import { AppModule } from "./app.module";
 import { ConfigService } from "./config/config.service";
-import { AppLogger } from "./logger/app-logger";
-import cookieParser from "cookie-parser";
 import { createSession } from "./jira/session-setup";
+import { AppLogger } from "./logger/app-logger";
 
 const options =
   process.env.NODE_ENV === "development"
@@ -27,8 +27,11 @@ const options =
   app.useLogger(new AppLogger(configService));
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
   app.useGlobalPipes(new ValidationPipe());
+
+  // express-session setup.
   app.set("trust proxy", configService.config.trustProxyIps);
   app.use(createSession(configService));
   app.use(cookieParser());
+
   await app.listen(configService.config.port);
 })();

--- a/server/src/session/session.module.ts
+++ b/server/src/session/session.module.ts
@@ -4,7 +4,6 @@ import { SessionService } from "./session.service";
 
 @Module({
   providers: [SessionService, SessionResolver],
-
   exports: [SessionService],
 })
 export class SessionModule {}


### PR DESCRIPTION
`express-session` currently fails in AWS because it tries to connect to Postgres without SSL.