### PR TITLE
Better name for Dependabot update group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: daily
     groups:
-      grouped:
+      npm:
         applies-to: version-updates
         update-types:
           - patch


### PR DESCRIPTION
I didn't realize the group name is used in pull requests, so this PR just adjusts that to bet a little bit better.

![Screenshot 2025-04-24 at 8 05 34](https://github.com/user-attachments/assets/9b1663b7-cbf1-456b-8335-9d979cd77c8b)
