### PR TITLE
Add missing mock data and E2E test for remaining hours calculation

### DIFF
--- a/e2e/fixtures/entry-browser/entry-browser.ts
+++ b/e2e/fixtures/entry-browser/entry-browser.ts
@@ -7,7 +7,9 @@ export class EntryBrowser {
     private t: TFunction,
   ) {}
 
-  getFirstAddEntryButton() {
-    return this.page.getByLabel(this.t("controls.addEntry")).first();
+  getAddEntryButton(date: string) {
+    return this.page.getByLabel(
+      this.t("controls.addEntryWithDate", { date, interpolation: { escapeValue: false } }),
+    );
   }
 }

--- a/e2e/fixtures/i18n.fixture.ts
+++ b/e2e/fixtures/i18n.fixture.ts
@@ -26,4 +26,7 @@ export const i18nFixture = test.extend(
  * This is not the full type, rather just a crude approximation of the only
  * way we use it.
  */
-export type TFunction = (key: string) => string;
+export type TFunction = (
+  key: string,
+  options?: Record<string, any> & { interpolation?: { escapeValue?: boolean } },
+) => string;

--- a/e2e/tests/entry-form.spec.ts
+++ b/e2e/tests/entry-form.spec.ts
@@ -66,14 +66,10 @@ test.describe("Entry form", () => {
     await expect(entryForm.getRemainingHoursToggle()).toBeChecked();
   });
 
-  // FIXME: Enable this after the related bug has been fixed.
-  test.skip("Remaining hours are calculated correctly", async ({
-    page,
-    entryBrowser,
-    entryForm,
-  }) => {
+  test("Remaining hours are calculated correctly", async ({ page, entryBrowser, entryForm }) => {
     await page.goto("/entries/week/2024-05-13");
-    await entryBrowser.getFirstAddEntryButton().click();
+    await page.waitForTimeout(1000);
+    await entryBrowser.getAddEntryButton("13/05/").click();
     await entryForm.getRemainingHoursToggle().check();
 
     await expect(entryForm.getHoursField()).toHaveText("02");

--- a/nv-mock/data/getworkdays-13-5-24.nv.xml
+++ b/nv-mock/data/getworkdays-13-5-24.nv.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<Root>
+    <ResponseStatus>
+        <Status>OK</Status>
+        <TimeStamp>14.5.2024 14:35:56</TimeStamp>
+    </ResponseStatus>
+    <WorkDays>
+        <Workday>
+            <Date>2024-05-13</Date>
+            <WorkdayHour netvisorkey="2412">
+                <Hours>5</Hours>
+                <CollectorRatio number="100" netvisorkey="3">01. Normaali tuntityö</CollectorRatio>
+                <AcceptanceStatus>Kuitattu</AcceptanceStatus>
+                <Description />
+                <CrmProcessName />
+                <Dimension>
+                    <DimensionName>1 Tuote</DimensionName>
+                    <DimensionItem>Hieno tuote</DimensionItem>
+                </Dimension>
+                <Dimension>
+                    <DimensionName>2 Toiminto</DimensionName>
+                    <DimensionItem>Toteutus</DimensionItem>
+                </Dimension>
+            </WorkdayHour>
+        </Workday>
+    </WorkDays>
+</Root>

--- a/nv-mock/nv-mock.json
+++ b/nv-mock/nv-mock.json
@@ -159,6 +159,40 @@
           "default": false,
           "crudKey": "id",
           "callbacks": []
+        },
+        {
+          "uuid": "a31de0ac-2b73-403f-9e27-5dfe31b2abf6",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "FILE",
+          "filePath": "data/getworkdays-13-5-24.nv.xml",
+          "databucketID": "",
+          "sendFileAsBody": true,
+          "rules": [
+            {
+              "target": "query",
+              "modifier": "workhourstartdate",
+              "value": "2024-05-13",
+              "invert": false,
+              "operator": "equals"
+            },
+            {
+              "target": "query",
+              "modifier": "workhourenddate",
+              "value": "2024-05-13",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
         }
       ],
       "responseMode": null

--- a/nv-mock/nv-mock.json
+++ b/nv-mock/nv-mock.json
@@ -187,7 +187,7 @@
               "operator": "equals"
             }
           ],
-          "rulesOperator": "OR",
+          "rulesOperator": "AND",
           "disableTemplating": false,
           "fallbackTo404": false,
           "default": false,

--- a/web/src/components/entry-dialog/EntryDialogButton.tsx
+++ b/web/src/components/entry-dialog/EntryDialogButton.tsx
@@ -14,10 +14,17 @@ const EntryDialogButton = ({ date, ...props }: EntryDialogButtonProps) => {
   const location = useLocation();
   const { t } = useTranslation();
 
+  const label = date
+    ? t("controls.addEntryWithDate", {
+        date: date.format("L").toString(),
+        interpolation: { escapeValue: false },
+      })
+    : t("controls.addEntry");
+
   return (
     <Box onClick={(e) => e.stopPropagation()}>
       <LabelledIconButton
-        label={t("controls.addEntry")}
+        label={label}
         onClick={() =>
           navigate(generatePath(`${location.pathname}/create`), {
             state: { date: date?.format("YYYY-MM-DD") },

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -10,6 +10,7 @@ const en = {
     confirmDelete: "Confirm delete",
     confirmDeleteForDialog: "Really delete this entry?",
     addEntry: "Add New Entry",
+    addEntryWithDate: "Add New Entry on {{date}}",
     deleteEntry: "Delete entry",
     editEntry: "Edit entry",
     selectWeek: "Week",

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -10,6 +10,7 @@ const fi = {
     confirmDelete: "Vahvista poisto",
     confirmDeleteForDialog: "Vahvista merkinnän poisto",
     addEntry: "Lisää työaikakirjaus",
+    addEntryWithDate: "Lisää työaikakirjaus {{date}}",
     deleteEntry: "Poista merkintä",
     editEntry: "Muokkaa merkintää",
     selectWeek: "Viikko",


### PR DESCRIPTION
- `nv-mock` was missing a response with only the entries of 13.5.2024 which caused the remaining hours calculation to be skipped.
- E2E test for remaining hours calculation.