### PR TITLE
Limit intermediate CI Docker image retention period to save artifact storage space

### DIFF
--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           name: keijo-test
           path: /tmp/keijo-test.tar
+          retention-days: 1
       # This is the production image for E2E testing and release.
       - name: Build production image
         uses: docker/build-push-action@v6
@@ -41,3 +42,4 @@ jobs:
         with:
           name: keijo
           path: /tmp/keijo.tar
+          retention-days: 1


### PR DESCRIPTION
Saves space in GitHub artifact storage. Has not been issue for this repository, but better to limit the retention period anyway because the Docker images are not needed once the CI run had ended.