### PR TITLE
Fix recent issues Jira query

### DIFF
--- a/web/src/jira/jira-types.ts
+++ b/web/src/jira/jira-types.ts
@@ -13,3 +13,21 @@ export type JiraIssueResult = {
   nextPageToken: string;
   isLast: boolean;
 };
+
+export type JiraProject = {
+  id: string;
+  key: string;
+  self: string;
+  expand: string;
+  name: string;
+  projectTypeKey: string;
+  isPrivate: boolean;
+};
+
+export type JiraProjectResult = {
+  maxResults: number;
+  startAt: number;
+  total: number;
+  isLast: boolean;
+  values: JiraProject[];
+};


### PR DESCRIPTION
After fixing and deploying [KEIJO-149](https://funidata.atlassian.net/browse/KEIJO-149), two issues were found in recent issues query:

- List of project keys may include removed projects or random strings. If either of these are present, the query will fail as Jira API requires all project keys in the filter to exists.
- Project keys are not quoted causing the query to fail with a syntax error if a key equals a JQL keyword.

This PR escapes the project keys used in the query properly and filters them to include only projects that actually exist in Jira.

[KEIJO-149]: https://funidata.atlassian.net/browse/KEIJO-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ