### PR TITLE
[chore]: Update Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,8 @@ updates:
       - "server"
       - "web"
     schedule:
-      interval: "weekly"
+      interval: "cron"
+      cronjob: "0 6 * * Mon%2"
     groups:
       npm:
         applies-to: "version-updates"
@@ -17,8 +18,10 @@ updates:
       - "server"
       - "web"
     schedule:
-      interval: "monthly"
+      interval: "cron"
+      cronjob: "0 6 * * Mon%2"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "cron"
+      cronjob: "0 6 * * Mon%2"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 updates:
   - package-ecosystem: "npm"
     directories:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,10 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 6 * * Mon%2"
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
       npm:
         applies-to: "version-updates"
@@ -20,8 +24,12 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "0 6 * * Mon%2"
+    cooldown:
+      default-days: 14
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "cron"
       cronjob: "0 6 * * Mon%2"
+    cooldown:
+      default-days: 14

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,7 +11,7 @@ updates:
       npm:
         applies-to: "version-updates"
         update-types:
-          - "minor"
+          - "patch"
   - package-ecosystem: "docker"
     directories:
       - "server"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,26 +1,24 @@
-version: 2
-
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: docker
+  - package-ecosystem: "npm"
     directories:
-      - server
-      - web
+      - "/"
+      - "e2e"
+      - "server"
+      - "web"
     schedule:
-      interval: daily
-  - package-ecosystem: npm
-    directories:
-      - e2e
-      - server
-      - web
-    schedule:
-      interval: daily
+      interval: "weekly"
     groups:
       npm:
-        applies-to: version-updates
+        applies-to: "version-updates"
         update-types:
-          - patch
-          - minor
+          - "minor"
+  - package-ecosystem: "docker"
+    directories:
+      - "server"
+      - "web"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
KEIJO-166

Updating Dependabot alerts to be be run on a cron schedule every two weeks, and to have a cooldown period of 3-14 days.
- The cooldown period helps let us avoid vulnerable updates.
- We are trying 2 week schedule to avoid weekly clutter but not have to wait a whole month for updates either.