### PR TITLE
[EntryDialog]: Fix heading

### DIFF
--- a/e2e/tests/general.spec.ts
+++ b/e2e/tests/general.spec.ts
@@ -8,7 +8,13 @@ test.describe("App bar", () => {
 
   test("Opens entry dialog", async ({ page, t, appBar }) => {
     await appBar.openEntryForm();
-    await expect(page.getByRole("heading", { name: t("entryDialog.title.edit") })).toBeVisible();
+
+    const dialog = page.getByRole("dialog", { name: t("entryDialog.title.create") });
+
+    await expect(dialog).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: t("entryDialog.title.create") }),
+    ).toBeVisible();
   });
 
   test("Switches between light and dark mode", async ({ appBar, page }) => {

--- a/web/src/components/entry-dialog/EntryDialog.tsx
+++ b/web/src/components/entry-dialog/EntryDialog.tsx
@@ -3,10 +3,10 @@ import BigDialog from "../BigDialog";
 import EntryForm from "./EntryForm";
 
 type EntryDialogProps = {
-  variant: "create" | "edit";
+  variant?: "create" | "edit";
 };
 
-const EntryDialog = ({ variant }: EntryDialogProps) => {
+const EntryDialog = ({ variant = "create" }: EntryDialogProps) => {
   const { t } = useTranslation();
 
   const titleKey = variant === "create" ? "entryDialog.title.create" : "entryDialog.title.edit";
@@ -16,10 +16,6 @@ const EntryDialog = ({ variant }: EntryDialogProps) => {
       <EntryForm />
     </BigDialog>
   );
-};
-
-EntryDialog.defaultProps = {
-  variant: "create",
 };
 
 export default EntryDialog;


### PR DESCRIPTION
KEIJO-141

- In React 19 `defaultProps` were removed from function components
  - Instead, assigned the default `variant` value in the function parameters
  - Made the property optional so `router.tsx` did not need any changes

--> Headings should update correctly between _Add New Entry_ and _Edit Entry_

- Fixed Playwright test
  - The previous implementation was enforcing the wrong dialog heading and that is why it wasn't failing even with the wrong title in the dialog
  - After fixing the heading, the test had strict mode violation where multiple heading elements were found
  - Scoped the query only for heading inside dialog