### PR TITLE
[hotfix]: remove Graph iQL setting

### DIFF
--- a/server/src/graphql-module-config.ts
+++ b/server/src/graphql-module-config.ts
@@ -11,7 +11,6 @@ if (process.env.NODE_ENV !== "production") {
 const graphQlModuleConfig: ApolloDriverConfig = {
   autoSchemaFile: true,
   driver: ApolloDriver,
-  graphiql: true,
   playground: false,
   plugins,
 };


### PR DESCRIPTION
DS-663 

Removed the `graphiql: true` since it is breaking dev environment. We are not using the playground anyway, so it's ok to remove this setting (it was supposed to replace the default playground, but does not seem to be doing so despite `playground: false`).