### PR TITLE
[BigDeleteEntryButton]: EntryDialog not closing after entry deletion in mobile

### DIFF
--- a/web/src/components/entry-dialog/BigDeleteEntryButton.tsx
+++ b/web/src/components/entry-dialog/BigDeleteEntryButton.tsx
@@ -9,9 +9,10 @@ import { useNotification } from "../global-notification/useNotification";
 type DeleteEntryButtonProps = {
   entryKey: string;
   date: Dayjs;
+  onDeleted?: () => void;
 };
 
-const BigDeleteEntryButton = ({ entryKey, date }: DeleteEntryButtonProps) => {
+const BigDeleteEntryButton = ({ entryKey, date, onDeleted }: DeleteEntryButtonProps) => {
   const { showSuccessNotification } = useNotification();
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -31,10 +32,11 @@ const BigDeleteEntryButton = ({ entryKey, date }: DeleteEntryButtonProps) => {
   };
 
   const onConfirm = async () => {
-    removeWorkdayEntry({
+    await removeWorkdayEntry({
       variables: { entry: { key: entryKey, date: date.format("YYYY-MM-DD") } },
     });
     onClose();
+    onDeleted?.();
   };
 
   return (

--- a/web/src/components/entry-dialog/BigDeleteEntryButton.tsx
+++ b/web/src/components/entry-dialog/BigDeleteEntryButton.tsx
@@ -16,7 +16,7 @@ const BigDeleteEntryButton = ({ entryKey, date, onDeleted }: DeleteEntryButtonPr
   const { showSuccessNotification } = useNotification();
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const [removeWorkdayEntry] = useMutation(RemoveWorkdayEntryDocument, {
+  const [removeWorkdayEntry, { loading }] = useMutation(RemoveWorkdayEntryDocument, {
     refetchQueries: [FindWorkdaysDocument],
     onCompleted: () => {
       showSuccessNotification(t("notifications.deleteEntry.success"));
@@ -49,10 +49,10 @@ const BigDeleteEntryButton = ({ entryKey, date, onDeleted }: DeleteEntryButtonPr
           {t("controls.confirmDeleteForDialog")}
         </DialogTitle>
         <DialogActions>
-          <Button onClick={onClose} color="secondary">
+          <Button onClick={onClose} color="secondary" disabled={loading}>
             {t("controls.cancel")}
           </Button>
-          <Button onClick={onConfirm} autoFocus>
+          <Button onClick={onConfirm} autoFocus loading={loading}>
             {t("controls.deleteEntry")}
           </Button>
         </DialogActions>

--- a/web/src/components/entry-dialog/EntryForm.tsx
+++ b/web/src/components/entry-dialog/EntryForm.tsx
@@ -217,7 +217,11 @@ const EntryForm = () => {
             </Grid>
             <Grid size={12}>
               {editEntry && originalDate && (
-                <BigDeleteEntryButton entryKey={editEntry.key} date={dayjs(originalDate)} />
+                <BigDeleteEntryButton
+                  entryKey={editEntry.key}
+                  date={dayjs(originalDate)}
+                  onDeleted={() => navigate("..")}
+                />
               )}
             </Grid>
             <Grid size={12}>


### PR DESCRIPTION
KEIJO-140

- The issue was that there was no parent-child communication about closing the EntryDialog
  - Added new `onDeleted` callback prop for `DeleteEntryButtonProps`
  - Added `await` for the delete mutation
  - Passed a callback from parent EntryForm to close the dialog route after delete
    - Dialogs are route based, e.g. `/entries/week/edit` and `/entries/week/create`
    - `navigate("..")` returns to the parent route, i.e. closing the dialog
- Extra: Added `loading` and `disabled` props for "_Cancel_" and "_Delete Entry_" buttons in the confirmation dialog
  - This prevents possible double clicks/submits 