### PR TITLE
[chore]: Update generated GraphQL types

### DIFF
--- a/web/codegen.yaml
+++ b/web/codegen.yaml
@@ -1,8 +1,17 @@
 schema: http://localhost:3001/graphql
 documents: "./src/**/*.graphql"
+config:
+  scalars:
+    DateTime: string
 generates:
-  ./src/graphql/generated/graphql.ts:
+  ./src/graphql/generated/schema-types.ts:
     plugins:
       - typescript
+  ./src/graphql/generated/graphql.ts:
+    plugins:
+      - add:
+          content: "export * from './schema-types';"
       - typescript-operations
       - typed-document-node
+    config:
+      importSchemaTypesFrom: "./src/graphql/generated/schema-types"

--- a/web/codegen.yaml
+++ b/web/codegen.yaml
@@ -15,3 +15,5 @@ generates:
       - typed-document-node
     config:
       importSchemaTypesFrom: "./src/graphql/generated/schema-types"
+      scalars:
+        DateTime: string

--- a/web/src/components/entry-dialog/useEntryForm.tsx
+++ b/web/src/components/entry-dialog/useEntryForm.tsx
@@ -113,9 +113,13 @@ const useEntryForm = ({ editEntry, date }: useEntryProps) => {
       throw new Error("Original entry not given.");
     }
 
+    if (!date) {
+      throw new Error("Original date not given.");
+    }
+
     await replaceWorkdayEntryMutation({
       variables: {
-        originalEntry: { key: editEntry.key, date: date?.format("YYYY-MM-DD") },
+        originalEntry: { key: editEntry.key, date: date.format("YYYY-MM-DD") },
         replacementEntry: {
           date: newDate.format("YYYY-MM-DD"),
           duration: Number(duration),

--- a/web/src/components/workday-browser/WorkdayList.tsx
+++ b/web/src/components/workday-browser/WorkdayList.tsx
@@ -3,17 +3,16 @@ import { Box, Button, Collapse, Paper } from "@mui/material";
 import { range } from "lodash";
 import useDayjs from "../../common/useDayjs";
 import {
-  Entry,
   FindWorkdaysDocument,
   GetMySettingsDocument,
   UpdateSettingsDocument,
+  Workday,
 } from "../../graphql/generated/graphql";
 import WorkdayAccordion from "../workday-accordion/WorkdayAccordion";
 import LoadingIndicator from "./LoadingIndicator";
 import TotalHours from "./TotalHours";
 import { useWorkdayBrowserParams } from "./useWorkdayBrowserParams";
 import { isWeekend } from "../../common/workdayUtils";
-import { Dayjs } from "dayjs";
 import { t } from "i18next";
 
 const WorkdayList = () => {
@@ -46,18 +45,18 @@ const WorkdayList = () => {
   };
 
   // Construct requested date range to include days without entries.
-  const workdays = range(normalizedEnd.diff(normalizedStart, "day") + 1).map((i) => {
+  const workdays: Workday[] = range(normalizedEnd.diff(normalizedStart, "day") + 1).map((i) => {
     const date = normalizedStart.add(i, "day");
     return {
-      date,
+      date: date.format("YYYY-MM-DD"),
       entries: data.findWorkdays.find((wd) => date.isSame(dayjs(wd.date), "day"))?.entries || [],
     };
   });
 
-  const dividedWorkdays = workdays.reduce<{ date: Dayjs; entries: Entry[] }[][]>((arr, curr) => {
+  const dividedWorkdays = workdays.reduce<Workday[][]>((arr, curr) => {
     if (
       arr.length === 0 ||
-      isWeekend(curr.date) !== isWeekend(arr.slice(-1)[0].slice(-1)[0].date)
+      isWeekend(dayjs(curr.date)) !== isWeekend(dayjs(arr.slice(-1)[0].slice(-1)[0].date))
     ) {
       arr.push([curr]);
     } else {
@@ -71,16 +70,16 @@ const WorkdayList = () => {
       <TotalHours workdays={workdays} />
       <Paper>
         {dividedWorkdays.map((wdArr) => {
-          if (isWeekend(wdArr[0].date)) {
+          if (isWeekend(dayjs(wdArr[0].date))) {
             return (
-              <Collapse in={showWeekend} key={wdArr[0].date.toString()}>
+              <Collapse in={showWeekend} key={wdArr[0].date}>
                 {wdArr.map((wd) => (
-                  <WorkdayAccordion workday={wd} key={wd.date.toString()} />
+                  <WorkdayAccordion workday={wd} key={wd.date} />
                 ))}
               </Collapse>
             );
           }
-          return wdArr.map((wd) => <WorkdayAccordion workday={wd} key={wd.date.toString()} />);
+          return wdArr.map((wd) => <WorkdayAccordion workday={wd} key={wd.date} />);
         })}
       </Paper>
       <Box sx={{ textAlign: "left", mt: "1em" }}>

--- a/web/src/graphql/generated/graphql.ts
+++ b/web/src/graphql/generated/graphql.ts
@@ -19,12 +19,12 @@ export type FindDimensionOptionsQueryVariables = Exact<{ [key: string]: never; }
 export type FindDimensionOptionsQuery = { findDimensionOptions: { product: Array<string>, activity: Array<string>, issue: Array<string>, client: Array<string> } };
 
 export type FindWorkdaysQueryVariables = Exact<{
-  start: unknown;
-  end: unknown;
+  start: string;
+  end: string;
 }>;
 
 
-export type FindWorkdaysQuery = { findWorkdays: Array<{ date: unknown, entries: Array<{ key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: Types.AcceptanceStatus, typeName: string, ratioNumber: number | null, product: string | null, activity: string | null, issue: string | null, client: string | null }> }> };
+export type FindWorkdaysQuery = { findWorkdays: Array<{ date: string, entries: Array<{ key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: Types.AcceptanceStatus, typeName: string, ratioNumber: number | null, product: string | null, activity: string | null, issue: string | null, client: string | null }> }> };
 
 export type GetSessionStatusQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/web/src/graphql/generated/graphql.ts
+++ b/web/src/graphql/generated/graphql.ts
@@ -2,171 +2,12 @@
 type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 /** Internal type. DO NOT USE DIRECTLY. */
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+import type * as Types from './schema-types';
+
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-/** All built-in and custom scalars, mapped to their actual values */
-export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: unknown; output: unknown; }
-};
-
-export enum AcceptanceStatus {
-  Accepted = 'Accepted',
-  Checked = 'Checked',
-  Open = 'Open',
-  Paid = 'Paid'
-}
-
-export type AddWorkdayEntryInput = {
-  activity?: InputMaybe<Scalars['String']['input']>;
-  client?: InputMaybe<Scalars['String']['input']>;
-  date: Scalars['DateTime']['input'];
-  description: Scalars['String']['input'];
-  duration: Scalars['Float']['input'];
-  issue?: InputMaybe<Scalars['String']['input']>;
-  product?: InputMaybe<Scalars['String']['input']>;
-};
-
-export type DimensionOptions = {
-  __typename?: 'DimensionOptions';
-  activity: Array<Scalars['String']['output']>;
-  client: Array<Scalars['String']['output']>;
-  issue: Array<Scalars['String']['output']>;
-  product: Array<Scalars['String']['output']>;
-};
-
-export type Entry = {
-  __typename?: 'Entry';
-  acceptanceStatus: AcceptanceStatus;
-  activity?: Maybe<Scalars['String']['output']>;
-  client?: Maybe<Scalars['String']['output']>;
-  description: Scalars['String']['output'];
-  duration: Scalars['Float']['output'];
-  durationInHours: Scalars['Boolean']['output'];
-  issue?: Maybe<Scalars['String']['output']>;
-  key: Scalars['String']['output'];
-  product?: Maybe<Scalars['String']['output']>;
-  ratioNumber?: Maybe<Scalars['Float']['output']>;
-  typeName: Scalars['String']['output'];
-};
-
-export type FindWorkdaysInput = {
-  end: Scalars['DateTime']['input'];
-  start: Scalars['DateTime']['input'];
-};
-
-export type Mutation = {
-  __typename?: 'Mutation';
-  addWorkdayEntry: Scalars['String']['output'];
-  removeWorkdayEntry: Scalars['String']['output'];
-  replaceWorkdayEntry: Scalars['String']['output'];
-  updateSettings: UserSettings;
-};
-
-
-export type MutationAddWorkdayEntryArgs = {
-  entry: AddWorkdayEntryInput;
-};
-
-
-export type MutationRemoveWorkdayEntryArgs = {
-  entry: RemoveWorkdayEntryInput;
-};
-
-
-export type MutationReplaceWorkdayEntryArgs = {
-  originalEntry: RemoveWorkdayEntryInput;
-  replacementEntry: AddWorkdayEntryInput;
-};
-
-
-export type MutationUpdateSettingsArgs = {
-  settings: UpdateSettingsDto;
-};
-
-export type Query = {
-  __typename?: 'Query';
-  findDimensionOptions: DimensionOptions;
-  findWorkdays: Array<Workday>;
-  getMySettings: UserSettings;
-  getSessionStatus: SessionStatus;
-};
-
-
-export type QueryFindWorkdaysArgs = {
-  query: FindWorkdaysInput;
-};
-
-export type RemoveWorkdayEntryInput = {
-  date: Scalars['DateTime']['input'];
-  key: Scalars['String']['input'];
-};
-
-export type SessionStatus = {
-  __typename?: 'SessionStatus';
-  employeeNumber?: Maybe<Scalars['Float']['output']>;
-};
-
-export type UpdateSettingsDto = {
-  activityPreset?: InputMaybe<Scalars['String']['input']>;
-  jiraNotificationIgnore?: InputMaybe<Scalars['Boolean']['input']>;
-  productPreset?: InputMaybe<Scalars['String']['input']>;
-  setRemainingHours?: InputMaybe<Scalars['Boolean']['input']>;
-  showWeekend?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
-export type UserSettings = {
-  __typename?: 'UserSettings';
-  activityPreset?: Maybe<Scalars['String']['output']>;
-  employeeNumber: Scalars['Float']['output'];
-  jiraNotificationIgnore?: Maybe<Scalars['Boolean']['output']>;
-  productPreset?: Maybe<Scalars['String']['output']>;
-  setRemainingHours?: Maybe<Scalars['Boolean']['output']>;
-  showWeekend?: Maybe<Scalars['Boolean']['output']>;
-};
-
-export type Workday = {
-  __typename?: 'Workday';
-  date: Scalars['DateTime']['output'];
-  entries: Array<Entry>;
-};
-
-export type AcceptanceStatus =
-  | 'Accepted'
-  | 'Checked'
-  | 'Open'
-  | 'Paid';
-
-export type AddWorkdayEntryInput = {
-  activity?: string | null | undefined;
-  client?: string | null | undefined;
-  date: unknown;
-  description: string;
-  duration: number;
-  issue?: string | null | undefined;
-  product?: string | null | undefined;
-};
-
-export type RemoveWorkdayEntryInput = {
-  date: unknown;
-  key: string;
-};
-
-export type UpdateSettingsDto = {
-  activityPreset?: string | null | undefined;
-  jiraNotificationIgnore?: boolean | null | undefined;
-  productPreset?: string | null | undefined;
-  setRemainingHours?: boolean | null | undefined;
-  showWeekend?: boolean | null | undefined;
-};
-
+export * from './schema-types';
 export type AddWorkdayEntryMutationVariables = Exact<{
-  entry: AddWorkdayEntryInput;
+  entry: Types.AddWorkdayEntryInput;
 }>;
 
 
@@ -183,7 +24,7 @@ export type FindWorkdaysQueryVariables = Exact<{
 }>;
 
 
-export type FindWorkdaysQuery = { findWorkdays: Array<{ date: unknown, entries: Array<{ key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: AcceptanceStatus, typeName: string, ratioNumber: number | null, product: string | null, activity: string | null, issue: string | null, client: string | null }> }> };
+export type FindWorkdaysQuery = { findWorkdays: Array<{ date: unknown, entries: Array<{ key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: Types.AcceptanceStatus, typeName: string, ratioNumber: number | null, product: string | null, activity: string | null, issue: string | null, client: string | null }> }> };
 
 export type GetSessionStatusQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -191,15 +32,15 @@ export type GetSessionStatusQueryVariables = Exact<{ [key: string]: never; }>;
 export type GetSessionStatusQuery = { getSessionStatus: { employeeNumber: number | null } };
 
 export type RemoveWorkdayEntryMutationVariables = Exact<{
-  entry: RemoveWorkdayEntryInput;
+  entry: Types.RemoveWorkdayEntryInput;
 }>;
 
 
 export type RemoveWorkdayEntryMutation = { removeWorkdayEntry: string };
 
 export type ReplaceWorkdayEntryMutationVariables = Exact<{
-  originalEntry: RemoveWorkdayEntryInput;
-  replacementEntry: AddWorkdayEntryInput;
+  originalEntry: Types.RemoveWorkdayEntryInput;
+  replacementEntry: Types.AddWorkdayEntryInput;
 }>;
 
 
@@ -211,7 +52,7 @@ export type GetMySettingsQueryVariables = Exact<{ [key: string]: never; }>;
 export type GetMySettingsQuery = { getMySettings: { employeeNumber: number, productPreset: string | null, activityPreset: string | null, jiraNotificationIgnore: boolean | null, showWeekend: boolean | null, setRemainingHours: boolean | null } };
 
 export type UpdateSettingsMutationVariables = Exact<{
-  settings: UpdateSettingsDto;
+  settings: Types.UpdateSettingsDto;
 }>;
 
 

--- a/web/src/graphql/generated/graphql.ts
+++ b/web/src/graphql/generated/graphql.ts
@@ -1,11 +1,10 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 import { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: { input: string; output: string; }
@@ -13,7 +12,7 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }
   Float: { input: number; output: number; }
-  DateTime: { input: any; output: any; }
+  DateTime: { input: unknown; output: unknown; }
 };
 
 export enum AcceptanceStatus {
@@ -137,37 +136,66 @@ export type Workday = {
   entries: Array<Entry>;
 };
 
+export type AcceptanceStatus =
+  | 'Accepted'
+  | 'Checked'
+  | 'Open'
+  | 'Paid';
+
+export type AddWorkdayEntryInput = {
+  activity?: string | null | undefined;
+  client?: string | null | undefined;
+  date: unknown;
+  description: string;
+  duration: number;
+  issue?: string | null | undefined;
+  product?: string | null | undefined;
+};
+
+export type RemoveWorkdayEntryInput = {
+  date: unknown;
+  key: string;
+};
+
+export type UpdateSettingsDto = {
+  activityPreset?: string | null | undefined;
+  jiraNotificationIgnore?: boolean | null | undefined;
+  productPreset?: string | null | undefined;
+  setRemainingHours?: boolean | null | undefined;
+  showWeekend?: boolean | null | undefined;
+};
+
 export type AddWorkdayEntryMutationVariables = Exact<{
   entry: AddWorkdayEntryInput;
 }>;
 
 
-export type AddWorkdayEntryMutation = { __typename?: 'Mutation', addWorkdayEntry: string };
+export type AddWorkdayEntryMutation = { addWorkdayEntry: string };
 
 export type FindDimensionOptionsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type FindDimensionOptionsQuery = { __typename?: 'Query', findDimensionOptions: { __typename?: 'DimensionOptions', product: Array<string>, activity: Array<string>, issue: Array<string>, client: Array<string> } };
+export type FindDimensionOptionsQuery = { findDimensionOptions: { product: Array<string>, activity: Array<string>, issue: Array<string>, client: Array<string> } };
 
 export type FindWorkdaysQueryVariables = Exact<{
-  start: Scalars['DateTime']['input'];
-  end: Scalars['DateTime']['input'];
+  start: unknown;
+  end: unknown;
 }>;
 
 
-export type FindWorkdaysQuery = { __typename?: 'Query', findWorkdays: Array<{ __typename?: 'Workday', date: any, entries: Array<{ __typename?: 'Entry', key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: AcceptanceStatus, typeName: string, ratioNumber?: number | null, product?: string | null, activity?: string | null, issue?: string | null, client?: string | null }> }> };
+export type FindWorkdaysQuery = { findWorkdays: Array<{ date: unknown, entries: Array<{ key: string, duration: number, durationInHours: boolean, description: string, acceptanceStatus: AcceptanceStatus, typeName: string, ratioNumber: number | null, product: string | null, activity: string | null, issue: string | null, client: string | null }> }> };
 
 export type GetSessionStatusQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetSessionStatusQuery = { __typename?: 'Query', getSessionStatus: { __typename?: 'SessionStatus', employeeNumber?: number | null } };
+export type GetSessionStatusQuery = { getSessionStatus: { employeeNumber: number | null } };
 
 export type RemoveWorkdayEntryMutationVariables = Exact<{
   entry: RemoveWorkdayEntryInput;
 }>;
 
 
-export type RemoveWorkdayEntryMutation = { __typename?: 'Mutation', removeWorkdayEntry: string };
+export type RemoveWorkdayEntryMutation = { removeWorkdayEntry: string };
 
 export type ReplaceWorkdayEntryMutationVariables = Exact<{
   originalEntry: RemoveWorkdayEntryInput;
@@ -175,19 +203,19 @@ export type ReplaceWorkdayEntryMutationVariables = Exact<{
 }>;
 
 
-export type ReplaceWorkdayEntryMutation = { __typename?: 'Mutation', replaceWorkdayEntry: string };
+export type ReplaceWorkdayEntryMutation = { replaceWorkdayEntry: string };
 
 export type GetMySettingsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMySettingsQuery = { __typename?: 'Query', getMySettings: { __typename?: 'UserSettings', employeeNumber: number, productPreset?: string | null, activityPreset?: string | null, jiraNotificationIgnore?: boolean | null, showWeekend?: boolean | null, setRemainingHours?: boolean | null } };
+export type GetMySettingsQuery = { getMySettings: { employeeNumber: number, productPreset: string | null, activityPreset: string | null, jiraNotificationIgnore: boolean | null, showWeekend: boolean | null, setRemainingHours: boolean | null } };
 
 export type UpdateSettingsMutationVariables = Exact<{
   settings: UpdateSettingsDto;
 }>;
 
 
-export type UpdateSettingsMutation = { __typename?: 'Mutation', updateSettings: { __typename?: 'UserSettings', employeeNumber: number } };
+export type UpdateSettingsMutation = { updateSettings: { employeeNumber: number } };
 
 
 export const AddWorkdayEntryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"AddWorkdayEntry"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"entry"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AddWorkdayEntryInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"addWorkdayEntry"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"entry"},"value":{"kind":"Variable","name":{"kind":"Name","value":"entry"}}}]}]}}]} as unknown as DocumentNode<AddWorkdayEntryMutation, AddWorkdayEntryMutationVariables>;

--- a/web/src/graphql/generated/schema-types.ts
+++ b/web/src/graphql/generated/schema-types.ts
@@ -1,0 +1,132 @@
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DateTime: { input: string; output: string; }
+};
+
+export enum AcceptanceStatus {
+  Accepted = 'Accepted',
+  Checked = 'Checked',
+  Open = 'Open',
+  Paid = 'Paid'
+}
+
+export type AddWorkdayEntryInput = {
+  activity?: InputMaybe<Scalars['String']['input']>;
+  client?: InputMaybe<Scalars['String']['input']>;
+  date: Scalars['DateTime']['input'];
+  description: Scalars['String']['input'];
+  duration: Scalars['Float']['input'];
+  issue?: InputMaybe<Scalars['String']['input']>;
+  product?: InputMaybe<Scalars['String']['input']>;
+};
+
+export type DimensionOptions = {
+  __typename?: 'DimensionOptions';
+  activity: Array<Scalars['String']['output']>;
+  client: Array<Scalars['String']['output']>;
+  issue: Array<Scalars['String']['output']>;
+  product: Array<Scalars['String']['output']>;
+};
+
+export type Entry = {
+  __typename?: 'Entry';
+  acceptanceStatus: AcceptanceStatus;
+  activity?: Maybe<Scalars['String']['output']>;
+  client?: Maybe<Scalars['String']['output']>;
+  description: Scalars['String']['output'];
+  duration: Scalars['Float']['output'];
+  durationInHours: Scalars['Boolean']['output'];
+  issue?: Maybe<Scalars['String']['output']>;
+  key: Scalars['String']['output'];
+  product?: Maybe<Scalars['String']['output']>;
+  ratioNumber?: Maybe<Scalars['Float']['output']>;
+  typeName: Scalars['String']['output'];
+};
+
+export type FindWorkdaysInput = {
+  end: Scalars['DateTime']['input'];
+  start: Scalars['DateTime']['input'];
+};
+
+export type Mutation = {
+  __typename?: 'Mutation';
+  addWorkdayEntry: Scalars['String']['output'];
+  removeWorkdayEntry: Scalars['String']['output'];
+  replaceWorkdayEntry: Scalars['String']['output'];
+  updateSettings: UserSettings;
+};
+
+
+export type MutationAddWorkdayEntryArgs = {
+  entry: AddWorkdayEntryInput;
+};
+
+
+export type MutationRemoveWorkdayEntryArgs = {
+  entry: RemoveWorkdayEntryInput;
+};
+
+
+export type MutationReplaceWorkdayEntryArgs = {
+  originalEntry: RemoveWorkdayEntryInput;
+  replacementEntry: AddWorkdayEntryInput;
+};
+
+
+export type MutationUpdateSettingsArgs = {
+  settings: UpdateSettingsDto;
+};
+
+export type Query = {
+  __typename?: 'Query';
+  findDimensionOptions: DimensionOptions;
+  findWorkdays: Array<Workday>;
+  getMySettings: UserSettings;
+  getSessionStatus: SessionStatus;
+};
+
+
+export type QueryFindWorkdaysArgs = {
+  query: FindWorkdaysInput;
+};
+
+export type RemoveWorkdayEntryInput = {
+  date: Scalars['DateTime']['input'];
+  key: Scalars['String']['input'];
+};
+
+export type SessionStatus = {
+  __typename?: 'SessionStatus';
+  employeeNumber?: Maybe<Scalars['Float']['output']>;
+};
+
+export type UpdateSettingsDto = {
+  activityPreset?: InputMaybe<Scalars['String']['input']>;
+  jiraNotificationIgnore?: InputMaybe<Scalars['Boolean']['input']>;
+  productPreset?: InputMaybe<Scalars['String']['input']>;
+  setRemainingHours?: InputMaybe<Scalars['Boolean']['input']>;
+  showWeekend?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+export type UserSettings = {
+  __typename?: 'UserSettings';
+  activityPreset?: Maybe<Scalars['String']['output']>;
+  employeeNumber: Scalars['Float']['output'];
+  jiraNotificationIgnore?: Maybe<Scalars['Boolean']['output']>;
+  productPreset?: Maybe<Scalars['String']['output']>;
+  setRemainingHours?: Maybe<Scalars['Boolean']['output']>;
+  showWeekend?: Maybe<Scalars['Boolean']['output']>;
+};
+
+export type Workday = {
+  __typename?: 'Workday';
+  date: Scalars['DateTime']['output'];
+  entries: Array<Entry>;
+};


### PR DESCRIPTION
DS-663

- Fixed duplicate type generation from the `typescript-operations` v6 upgrade by splitting codegen into `schema-types.ts` (schema types) and graphql.ts (operations), which re-exports the former so existing imports are unaffected.
- Mapped the `DateTime` scalar to `string` (was unknown), keeping dates as strings and converting to `Dayjs` only where needed.
- Added a guard in `useEntryForm.tsx` for the optional date before formatting.