### PR TITLE
[chore]: Change dev server port to 3000

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
       - VITE_API_URL=http://localhost:3001/graphql
       - VITE_KEIJO_JIRA_API_URL=http://localhost:3001/jira
     ports:
-      - 3000:5173
+      - 3000:3000
 
   web-test:
     extends:

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,4 +7,4 @@ RUN npm ci
 
 COPY . .
 
-CMD ["npm", "run", "dev", "--", "--host"]
+CMD ["npm", "run", "dev", "--", "--port", "3000", "--host"]


### PR DESCRIPTION
KEIJO-181

Changed the Vite dev server port to 3000 so that when the dev server is started, the localhost link in the terminal when running `npm start` (or `npm run recycle`) shows correctly.
Previously the default port was 5173 and that port number was printed in the terminal, but the docker config exposes the dev server in port 3000, so the link in the terminal did not work.

<img width="479" height="219" alt="Screenshot 2026-06-18 at 16 21 18" src="https://github.com/user-attachments/assets/feafea09-c05b-4840-b3ba-2a28c1362aca" />
