### PR TITLE
[WorkdaySummary]: Indicate current workday

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
       - VITE_API_URL=http://localhost:4001/graphql
       - VITE_KEIJO_JIRA_API_URL=http://localhost:4001/jira
     ports:
-      - 4000:5173
+      - 4000:3000
 
   server:
     extends:

--- a/web/src/components/workday-accordion/WorkdaySummary.test.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.test.tsx
@@ -158,8 +158,4 @@ describe("WorkdaySummary", () => {
 
     vi.useRealTimers();
   });
-
-  describe("Fixed entries", () => {
-    it("shows 'Vacation' chip for a vacation day", () => {});
-  });
 });

--- a/web/src/components/workday-accordion/WorkdaySummary.test.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 afterEach(() => cleanup());
 import "../../i18n/i18n-config";
@@ -55,5 +55,33 @@ describe("WorkdaySummary", () => {
     renderWorkday({ date: "2026-06-13", entries: [] }); // Saturday
 
     expect(screen.getByText("Weekend")).toBeTruthy();
+  });
+
+  it("has aria-current='date' for current day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 10, 12, 0, 0)); // 2026-06-10 local time
+
+    renderWorkday({
+      date: "2026-06-10",
+      entries: [{ ...baseEntry, ratioNumber: EntryType.NormalWork }],
+    });
+
+    expect(document.querySelector('[aria-current="date"]')).toBeTruthy();
+
+    vi.useRealTimers();
+  });
+
+  it("does not set aria-current for non-current day", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 10, 12, 0, 0)); // 2026-06-10 local time
+
+    renderWorkday({
+      date: "2026-06-11",
+      entries: [{ ...baseEntry, ratioNumber: EntryType.NormalWork }],
+    });
+
+    expect(document.querySelector('[aria-current="date"]')).toBeNull();
+
+    vi.useRealTimers();
   });
 });

--- a/web/src/components/workday-accordion/WorkdaySummary.test.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.test.tsx
@@ -51,6 +51,80 @@ describe("WorkdaySummary", () => {
     expect(screen.queryByText(/\d+:\d+ h/)).toBeNull();
   });
 
+  it("shows 'Holiday Pay Leave' chip for paid leave day", () => {
+    renderWorkday({
+      date: "2026-06-10",
+      entries: [{ ...baseEntry, ratioNumber: EntryType.HolidayPayLeave }],
+    });
+
+    expect(screen.getByText("Holiday Pay Leave")).toBeTruthy();
+    // Hours chip is hidden for special single-entry days like holiday pay leave
+    expect(screen.queryByText(/\d+:\d+ h/)).toBeNull();
+  });
+
+  it("shows 'Sick Leave' chip for sick leave day", () => {
+    renderWorkday({
+      date: "2026-06-10",
+      entries: [{ ...baseEntry, ratioNumber: EntryType.SickLeave }],
+    });
+
+    expect(screen.getByText("Sick Leave")).toBeTruthy();
+    // Hours chip is hidden for special single-entry days like sick leave
+    expect(screen.queryByText(/\d+:\d+ h/)).toBeNull();
+  });
+
+  it("shows 'Flex Leave' chip for flex leave day", () => {
+    renderWorkday({
+      date: "2026-06-10",
+      entries: [
+        {
+          ...baseEntry,
+          key: "1",
+          ratioNumber: EntryType.FlexLeave,
+          duration: 1,
+          durationInHours: false,
+        },
+        {
+          ...baseEntry,
+          key: "2",
+          ratioNumber: EntryType.NormalWork,
+          duration: 0,
+          durationInHours: true,
+        },
+      ],
+    });
+
+    expect(screen.getByText("Flex Leave")).toBeTruthy();
+    // Hours chip is hidden for special single-entry days like flex leave day
+    expect(screen.queryByText(/\d+:\d+ h/)).toBeNull();
+  });
+
+  it("does not show 'Flex Leave' chip without zero hour normal work entry", () => {
+    renderWorkday({
+      date: "2026-06-10",
+      entries: [
+        {
+          ...baseEntry,
+          key: "1",
+          ratioNumber: EntryType.FlexLeave,
+          duration: 1,
+          durationInHours: false,
+        },
+      ],
+    });
+
+    expect(screen.queryByText("Flex Leave")).toBeNull();
+  });
+
+  it("shows 'Holiday' chip for  holiday", () => {
+    renderWorkday({
+      date: "2026-06-19", // Midsummer Eve in Finland
+      entries: [],
+    });
+
+    expect(screen.getByText("Holiday")).toBeTruthy();
+  });
+
   it("shows 'Weekend' chip for a Saturday", () => {
     renderWorkday({ date: "2026-06-13", entries: [] }); // Saturday
 
@@ -83,5 +157,9 @@ describe("WorkdaySummary", () => {
     expect(document.querySelector('[aria-current="date"]')).toBeNull();
 
     vi.useRealTimers();
+  });
+
+  describe("Fixed entries", () => {
+    it("shows 'Vacation' chip for a vacation day", () => {});
   });
 });

--- a/web/src/components/workday-accordion/WorkdaySummary.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.tsx
@@ -1,5 +1,6 @@
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { AccordionSummary, Box, Chip, Typography, useMediaQuery, useTheme } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import { roundToFullMinutes, totalDurationOfEntries } from "../../common/duration";
 import useDayjs from "../../common/useDayjs";
 import {
@@ -30,6 +31,7 @@ const WorkdaySummary = ({ workday }: WorkdayAccordionProps) => {
   const mobile = useMediaQuery(theme.breakpoints.down("md"));
   const dayjs = useDayjs();
   const date = dayjs(workday.date).locale(dayjs.locale());
+  const isCurrentDay = date.isSame(dayjs(), "day");
   const holiday = isHoliday(date);
   const weekend = isWeekend(date);
   const vacation = isVacation(workday);
@@ -69,7 +71,17 @@ const WorkdaySummary = ({ workday }: WorkdayAccordionProps) => {
   };
 
   return (
-    <AccordionSummary expandIcon={!disabled && <ExpandMoreIcon />}>
+    <AccordionSummary
+      expandIcon={!disabled && <ExpandMoreIcon />}
+      sx={{
+        border: isCurrentDay ? "1px solid" : "none",
+        borderColor: isCurrentDay ? "secondary.main" : "transparent",
+        backgroundColor: isCurrentDay
+          ? (theme) =>
+              alpha(theme.palette.secondary.main, theme.palette.mode === "dark" ? 0.4 : 0.6)
+          : "inherit",
+      }}
+    >
       <Box
         sx={{
           display: "flex",

--- a/web/src/components/workday-accordion/WorkdaySummary.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.tsx
@@ -73,6 +73,7 @@ const WorkdaySummary = ({ workday }: WorkdayAccordionProps) => {
   return (
     <AccordionSummary
       expandIcon={!disabled && <ExpandMoreIcon />}
+      aria-current={isCurrentDay ? "date" : undefined}
       sx={{
         border: isCurrentDay ? "1px solid" : "none",
         borderColor: isCurrentDay ? "secondary.main" : "transparent",

--- a/web/src/components/workday-accordion/WorkdaySummary.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.tsx
@@ -65,7 +65,7 @@ const WorkdaySummary = ({ workday }: WorkdayAccordionProps) => {
       return <HolidayChip />;
     }
     if (empty) {
-      return <NoEntriesChip />;
+      return <NoEntriesChip sx={{ borderColor: isCurrentDay ? "grey.800" : "grey.400" }} />;
     }
     return null;
   };
@@ -109,7 +109,15 @@ const WorkdaySummary = ({ workday }: WorkdayAccordionProps) => {
           {!disabled && (
             <>
               <EntryDialogButton date={date} size="medium" />
-              <Chip label={`${totalHoursFormatted} h`} sx={{ mr: 2, color: "inherit" }} />
+              <Chip
+                label={`${totalHoursFormatted} h`}
+                sx={{
+                  mr: 2,
+                  color: "inherit",
+                  border: isCurrentDay ? "1px solid" : "none",
+                  borderColor: isCurrentDay ? "grey.800" : "grey.400",
+                }}
+              />
             </>
           )}
           {disabled && !mobile && <Box sx={{ width: 133 }} />}

--- a/web/src/components/workday-accordion/info-chips/NoEntriesChip.tsx
+++ b/web/src/components/workday-accordion/info-chips/NoEntriesChip.tsx
@@ -1,14 +1,18 @@
-import { Chip } from "@mui/material";
+import { Chip, SxProps, Theme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
-const NoEntriesChip = () => {
+type NoEntriesChipProps = {
+  sx?: SxProps<Theme>;
+};
+
+const NoEntriesChip = ({ sx }: NoEntriesChipProps) => {
   const { t } = useTranslation();
 
   return (
     <Chip
       label={t("entryTable.noEntries")}
       variant="outlined"
-      style={{ color: "inherit", fontStyle: "italic" }}
+      sx={{ color: "inherit", fontStyle: "italic", ...sx }}
     />
   );
 };

--- a/web/src/components/workday-accordion/info-chips/SickLeaveChip.tsx
+++ b/web/src/components/workday-accordion/info-chips/SickLeaveChip.tsx
@@ -12,9 +12,7 @@ const SickLeaveChip = () => {
         color: "black",
         fontWeight: 500,
         bgcolor: (theme) =>
-          theme.palette.mode === "dark"
-            ? theme.palette.secondary.main
-            : theme.palette.secondary.main,
+          theme.palette.mode === "dark" ? theme.palette.primary.main : theme.palette.secondary.main,
       }}
     />
   );


### PR DESCRIPTION
KEIJO-147

- Added background color to current day accordion (_comments about the color welcome_)
  - Used `alpha()` to get more opacity options to get balanced colors for both light and dark modes (rather than just use fixed palette colors)
- Enhanced `NoEntriesChip` and total hours `Chip` in current day accordion with visible borders
- Fixed `SickLeaveChip` background color
- Added unit tests for all chips in `WorkdaySummary`
  
### Developer's checklist
- [x] I wrote unit tests for relevant components
- [ ] I created tickets for testing needs found during this PR that are outside the scope of this ticket
