### PR TITLE
[improvement]: Improve entry form filtering

### DIFF
--- a/web/src/components/entry-dialog/EntryFilterSection.test.tsx
+++ b/web/src/components/entry-dialog/EntryFilterSection.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import EntryFiltersSection from "./EntryFiltersSection";
+
+const entryFormFiltersMock = vi.hoisted(() => ({
+  useEntryFormFilters: vi.fn(),
+}));
+
+vi.mock("./useEntryFormFilters", () => ({
+  default: entryFormFiltersMock.useEntryFormFilters,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("./ProjectFilter", () => ({
+  default: () => <div data-testid="project-filter-stub">ProjectFilter</div>,
+}));
+
+vi.mock("@mui/material/Collapse", () => ({
+  default: ({ in: isOpen, children }: { in: boolean; children: ReactNode }) =>
+    isOpen ? <>{children}</> : null,
+}));
+
+const mockUseEntryFormFilters = (activeFilters: string[] = []) => {
+  entryFormFiltersMock.useEntryFormFilters.mockReturnValue({
+    filters: { projects: [] },
+    updateSelectedProjects: vi.fn(),
+    activeFilters,
+  });
+};
+
+describe("EntryFiltersSection", () => {
+  afterEach(() => cleanup());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseEntryFormFilters();
+  });
+
+  it("toggles the filtering section when the button is clicked", () => {
+    render(<EntryFiltersSection />);
+
+    expect(screen.getByRole("button", { name: /controls\.showFilters/ })).toBeTruthy();
+    expect(screen.queryByTestId("project-filter-stub")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /controls\.showFilters/ }));
+
+    expect(screen.getByRole("button", { name: /controls\.hideFilters/ })).toBeTruthy();
+    expect(screen.getByTestId("project-filter-stub")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /controls\.hideFilters/ }));
+
+    expect(screen.getByRole("button", { name: /controls\.showFilters/ })).toBeTruthy();
+    expect(screen.queryByTestId("project-filter-stub")).toBeNull();
+  });
+
+  it("shows the active filter count badge when filters are active", () => {
+    mockUseEntryFormFilters(["projects"]);
+
+    render(<EntryFiltersSection />);
+
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+});

--- a/web/src/components/entry-dialog/EntryFilterSection.test.tsx
+++ b/web/src/components/entry-dialog/EntryFilterSection.test.tsx
@@ -26,9 +26,9 @@ vi.mock("@mui/material/Collapse", () => ({
     isOpen ? <>{children}</> : null,
 }));
 
-const mockUseEntryFormFilters = (activeFilters: string[] = []) => {
+const mockUseEntryFormFilters = (activeFilters: string[] = [], selectedProjects: string[] = []) => {
   entryFormFiltersMock.useEntryFormFilters.mockReturnValue({
-    filters: { projects: [] },
+    filters: { projects: selectedProjects },
     updateSelectedProjects: vi.fn(),
     activeFilters,
   });
@@ -60,10 +60,10 @@ describe("EntryFiltersSection", () => {
   });
 
   it("shows the active filter count badge when filters are active", () => {
-    mockUseEntryFormFilters(["projects"]);
+    mockUseEntryFormFilters(["projects"], ["project-1", "project-2"]);
 
     render(<EntryFiltersSection />);
 
-    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
   });
 });

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -3,13 +3,17 @@ import Button from "@mui/material/Button";
 import ProjectFilter from "./ProjectFilter";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import useEntryFormFilters from "./useEntryFormFilters";
+import useEntryFormFilters, { type EntryFormFilterKey } from "./useEntryFormFilters";
 import Badge from "@mui/material/Badge";
 
 export default function EntryFiltersSection() {
   const [showFilters, setShowFilters] = useState(false);
   const { t } = useTranslation();
   const { filters, updateSelectedProjects, activeFilters } = useEntryFormFilters();
+  const filterValueCount = Object.entries(filters)
+    .filter(([key, value]) => activeFilters.includes(key as EntryFormFilterKey) && value.length > 0)
+    .map(([, value]) => value.length)
+    .reduce((acc, curr) => acc + curr, 0);
 
   return (
     <>
@@ -19,12 +23,12 @@ export default function EntryFiltersSection() {
         variant="text"
         color="secondary"
         aria-label={
-          showFilters ? undefined : t("controls.showFilters_aria", { count: activeFilters.length })
+          showFilters ? undefined : t("controls.showFilters_aria", { count: filterValueCount })
         }
         sx={{ marginBottom: 1, color: "secondary.dark" }}
       >
         {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
-        <Badge badgeContent={activeFilters.length} color="secondary" sx={{ ml: 2 }} />
+        <Badge badgeContent={filterValueCount} color="secondary" sx={{ ml: 2 }} />
       </Button>
       <Collapse in={showFilters}>
         <ProjectFilter

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -4,11 +4,12 @@ import ProjectFilter from "./ProjectFilter";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import useEntryFormFilters from "./useEntryFormFilters";
+import Badge from "@mui/material/Badge";
 
 export default function EntryFiltersSection() {
   const [showFilters, setShowFilters] = useState(false);
   const { t } = useTranslation();
-  const { filters, updateSelectedProjects } = useEntryFormFilters();
+  const { filters, updateSelectedProjects, activeFilters } = useEntryFormFilters();
 
   return (
     <>
@@ -16,9 +17,10 @@ export default function EntryFiltersSection() {
         onClick={() => setShowFilters((prev) => !prev)}
         size="small"
         variant="text"
-        aria-label={showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
+        aria-label={showFilters ? undefined : t("controls.showFilters_aria", { count: activeFilters.length })}
       >
         {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
+        <Badge badgeContent={activeFilters.length} color="primary" sx={{ ml: 2 }} />
       </Button>
       <Collapse in={showFilters}>
         <ProjectFilter

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -1,0 +1,26 @@
+import Collapse from "@mui/material/Collapse";
+import Button from "@mui/material/Button";
+import ProjectFilter from "./ProjectFilter";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export default function EntryFiltersSection() {
+  const [showFilters, setShowFilters] = useState(false);
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Button
+        onClick={() => setShowFilters((prev) => !prev)}
+        size="small"
+        variant="text"
+        aria-label={showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
+      >
+        {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
+      </Button>
+      <Collapse in={showFilters}>
+        <ProjectFilter />
+      </Collapse>
+    </>
+  );
+}

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -17,6 +17,7 @@ export default function EntryFiltersSection() {
         onClick={() => setShowFilters((prev) => !prev)}
         size="small"
         variant="text"
+        color="secondary"
         aria-label={
           showFilters ? undefined : t("controls.showFilters_aria", { count: activeFilters.length })
         }

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -3,10 +3,12 @@ import Button from "@mui/material/Button";
 import ProjectFilter from "./ProjectFilter";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import useEntryFormFilters from "./useEntryFormFilters";
 
 export default function EntryFiltersSection() {
   const [showFilters, setShowFilters] = useState(false);
   const { t } = useTranslation();
+  const { filters, updateSelectedProjects } = useEntryFormFilters();
 
   return (
     <>
@@ -19,7 +21,10 @@ export default function EntryFiltersSection() {
         {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
       </Button>
       <Collapse in={showFilters}>
-        <ProjectFilter />
+        <ProjectFilter
+          selectedProjects={filters.projects}
+          onProjectsChange={updateSelectedProjects}
+        />
       </Collapse>
     </>
   );

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -20,10 +20,10 @@ export default function EntryFiltersSection() {
         aria-label={
           showFilters ? undefined : t("controls.showFilters_aria", { count: activeFilters.length })
         }
-        sx={{ marginBottom: 1 }}
+        sx={{ marginBottom: 1, color: "secondary.dark" }}
       >
         {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
-        <Badge badgeContent={activeFilters.length} color="primary" sx={{ ml: 2 }} />
+        <Badge badgeContent={activeFilters.length} color="secondary" sx={{ ml: 2 }} />
       </Button>
       <Collapse in={showFilters}>
         <ProjectFilter

--- a/web/src/components/entry-dialog/EntryFiltersSection.tsx
+++ b/web/src/components/entry-dialog/EntryFiltersSection.tsx
@@ -17,7 +17,10 @@ export default function EntryFiltersSection() {
         onClick={() => setShowFilters((prev) => !prev)}
         size="small"
         variant="text"
-        aria-label={showFilters ? undefined : t("controls.showFilters_aria", { count: activeFilters.length })}
+        aria-label={
+          showFilters ? undefined : t("controls.showFilters_aria", { count: activeFilters.length })
+        }
+        sx={{ marginBottom: 1 }}
       >
         {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
         <Badge badgeContent={activeFilters.length} color="primary" sx={{ ml: 2 }} />

--- a/web/src/components/entry-dialog/EntryForm.tsx
+++ b/web/src/components/entry-dialog/EntryForm.tsx
@@ -7,7 +7,6 @@ import {
   Alert,
   Box,
   Button,
-  Collapse,
   FormControlLabel,
   FormGroup,
   Grid,
@@ -17,7 +16,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { Dayjs } from "dayjs";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { Controller, UseFormReturn } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -38,7 +37,7 @@ import JiraIssueComboBox from "./JiraIssueComboBox";
 import ResponsiveDatePicker from "./ResponsiveDatePicker";
 import WorkdayHours from "./WorkdayHours";
 import useEntryForm, { EntryFormSchema } from "./useEntryForm";
-import ProjectFilter from "./ProjectFilter";
+import EntryFiltersSection from "./EntryFiltersSection";
 
 export type EntryFormProps = {
   form: UseFormReturn<EntryFormSchema>;
@@ -81,7 +80,6 @@ const EntryForm = () => {
   const { userPrefersSetRemainingHours, toggleRemainingHours } = usePreferSetRemainingHours();
   const { control, watch } = form;
   const dateWatch = dayjs(watch("date")).locale(dayjs.locale());
-  const [showFilters, setShowFilters] = useState(false);
   const { isJiraAuth, isLoading } = useIsJiraAuthenticated();
 
   const { data } = useQuery(GetMySettingsDocument);
@@ -152,19 +150,7 @@ const EntryForm = () => {
               />
             </Grid>
             <Grid size={12}>
-              <Button
-                onClick={() => setShowFilters((prev) => !prev)}
-                size="small"
-                variant="text"
-                aria-label={showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
-              >
-                {showFilters ? t("controls.hideFilters") : t("controls.showFilters")}
-              </Button>
-            </Grid>
-            <Grid size={12}>
-              <Collapse in={showFilters}>
-                <ProjectFilter />
-              </Collapse>
+              <EntryFiltersSection />
             </Grid>
             {data && !data.getMySettings.jiraNotificationIgnore && !isJiraAuth && !isLoading ? (
               <Grid>

--- a/web/src/components/entry-dialog/ProjectFilter.test.tsx
+++ b/web/src/components/entry-dialog/ProjectFilter.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import ProjectFilter from "./ProjectFilter";
+
+const apolloMocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+}));
+
+vi.mock("@apollo/client/react", () => ({
+  useQuery: apolloMocks.useQuery,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockUseQuery = (issueKeys: string[]) => {
+  apolloMocks.useQuery.mockReturnValue({
+    data: {
+      findDimensionOptions: {
+        issue: issueKeys,
+      },
+    },
+  });
+};
+
+describe("ProjectFilter", () => {
+  afterEach(() => cleanup());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows thelabel and helper text", () => {
+    mockUseQuery([]);
+
+    render(<ProjectFilter selectedProjects={[]} />);
+
+    expect(screen.getByLabelText("entryDialog.filterProjects")).toBeTruthy();
+    expect(screen.getByText("entryDialog.filterProjectsHelperText")).toBeTruthy();
+  });
+
+  it("shows available project keys correctly as options", () => {
+    mockUseQuery(["ABC-1", "ABC-2", "bad-key", "DEF-7", "DEF-7", "GHI-10"]);
+
+    render(<ProjectFilter selectedProjects={[]} />);
+
+    const input = screen.getByLabelText("entryDialog.filterProjects");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    expect(screen.getByRole("option", { name: "ABC" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "DEF" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "GHI" })).toBeTruthy();
+  });
+
+  it("renders the selected projects as tags and shows the overflow count", () => {
+    mockUseQuery([]);
+
+    render(<ProjectFilter selectedProjects={["OPS", "FIN"]} />);
+
+    expect(screen.getByText("OPS")).toBeTruthy();
+    expect(screen.getByText("+1")).toBeTruthy();
+  });
+
+  it("calls onProjectsChange when the selection changes", () => {
+    mockUseQuery(["OPS-1", "FIN-2"]);
+    const onProjectsChange = vi.fn();
+
+    render(<ProjectFilter selectedProjects={[]} onProjectsChange={onProjectsChange} />);
+
+    const input = screen.getByLabelText("entryDialog.filterProjects");
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.click(screen.getByRole("option", { name: "OPS" }));
+
+    expect(onProjectsChange).toHaveBeenCalledWith(["OPS"]);
+  });
+});

--- a/web/src/components/entry-dialog/ProjectFilter.tsx
+++ b/web/src/components/entry-dialog/ProjectFilter.tsx
@@ -2,12 +2,14 @@ import { useQuery } from "@apollo/client/react";
 import { Autocomplete, Chip, FormControl, TextField } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { FindDimensionOptionsDocument } from "../../graphql/generated/graphql";
-import useEntryFormFilters from "./useEntryFormFilters";
 
-const ProjectFilter = () => {
+interface ProjectFilterProps {
+  selectedProjects: string[];
+  onProjectsChange?: (projects: string[]) => void;
+}
+
+export default function ProjectFilter({ selectedProjects, onProjectsChange }: ProjectFilterProps) {
   const { t } = useTranslation();
-  const { filters, updateSelectedProjects } = useEntryFormFilters();
-
   const { data } = useQuery(FindDimensionOptionsDocument);
   const issueKeys = data?.findDimensionOptions.issue || [];
   const projectKeys = [
@@ -19,10 +21,10 @@ const ProjectFilter = () => {
   return (
     <FormControl fullWidth>
       <Autocomplete
-        value={filters.projects}
+        value={selectedProjects}
         options={projectKeys}
         onChange={(_, value) => {
-          updateSelectedProjects(value);
+          onProjectsChange?.(value);
         }}
         renderValue={(value, getTagProps) => {
           const numTags = value.length;
@@ -41,6 +43,4 @@ const ProjectFilter = () => {
       />
     </FormControl>
   );
-};
-
-export default ProjectFilter;
+}

--- a/web/src/components/entry-dialog/ProjectFilter.tsx
+++ b/web/src/components/entry-dialog/ProjectFilter.tsx
@@ -1,35 +1,16 @@
-import { useApolloClient, useMutation, useQuery } from "@apollo/client/react";
+import { useQuery } from "@apollo/client/react";
 import { Autocomplete, Chip, FormControl, TextField } from "@mui/material";
-import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  FindDimensionOptionsDocument,
-  GetMySettingsDocument,
-  UpdateSettingsDocument,
-} from "../../graphql/generated/graphql";
+import { FindDimensionOptionsDocument } from "../../graphql/generated/graphql";
+import useEntryFormFilters from "./useEntryFormFilters";
 
 const ProjectFilter = () => {
   const { t } = useTranslation();
-  const client = useApolloClient();
-  const { data: settingsData } = useQuery(GetMySettingsDocument);
-  const [updateSettings] = useMutation(UpdateSettingsDocument, {
-    refetchQueries: [GetMySettingsDocument],
-  });
-
-  const serverPreset = settingsData?.getMySettings.projectsPreset;
-  const [selected, setSelected] = useState<string[]>([]);
-  const initialized = useRef(false);
-
-  useEffect(() => {
-    if (!initialized.current && serverPreset !== undefined) {
-      initialized.current = true;
-      setSelected(serverPreset ?? []);
-    }
-  }, [serverPreset]);
+  const { filters, updateSelectedProjects } = useEntryFormFilters();
 
   const { data } = useQuery(FindDimensionOptionsDocument);
   const issueKeys = data?.findDimensionOptions.issue || [];
-  const projects = [
+  const projectKeys = [
     ...new Set(
       issueKeys.filter((key) => /^[A-Za-z]+-\d+$/.test(key)).map((key) => key.split("-")[0]),
     ),
@@ -38,18 +19,10 @@ const ProjectFilter = () => {
   return (
     <FormControl fullWidth>
       <Autocomplete
-        value={selected}
-        options={projects}
+        value={filters.projects}
+        options={projectKeys}
         onChange={(_, value) => {
-          setSelected(value);
-          const existing = client.readQuery({ query: GetMySettingsDocument });
-          if (existing) {
-            client.writeQuery({
-              query: GetMySettingsDocument,
-              data: { getMySettings: { ...existing.getMySettings, projectsPreset: value } },
-            });
-          }
-          updateSettings({ variables: { settings: { projectsPreset: value } } });
+          updateSelectedProjects(value);
         }}
         renderValue={(value, getTagProps) => {
           const numTags = value.length;

--- a/web/src/components/entry-dialog/ProjectFilter.tsx
+++ b/web/src/components/entry-dialog/ProjectFilter.tsx
@@ -1,5 +1,9 @@
 import { useQuery } from "@apollo/client/react";
-import { Autocomplete, Chip, FormControl, TextField } from "@mui/material";
+import Autocomplete from "@mui/material/Autocomplete";
+import Chip from "@mui/material/Chip";
+import FormControl from "@mui/material/FormControl";
+import TextField from "@mui/material/TextField";
+import FormHelperText from "@mui/material/FormHelperText";
 import { useTranslation } from "react-i18next";
 import { FindDimensionOptionsDocument } from "../../graphql/generated/graphql";
 
@@ -7,6 +11,8 @@ interface ProjectFilterProps {
   selectedProjects: string[];
   onProjectsChange?: (projects: string[]) => void;
 }
+
+const helperId = "project-filter-helper-text";
 
 export default function ProjectFilter({ selectedProjects, onProjectsChange }: ProjectFilterProps) {
   const { t } = useTranslation();
@@ -40,7 +46,9 @@ export default function ProjectFilter({ selectedProjects, onProjectsChange }: Pr
         }}
         multiple
         renderInput={(params) => <TextField {...params} label={t("entryDialog.filterProjects")} />}
+        aria-describedby={helperId}
       />
+      <FormHelperText id={helperId}>{t("entryDialog.filterProjectsHelperText")}</FormHelperText>
     </FormControl>
   );
 }

--- a/web/src/components/entry-dialog/useEntryFormFilters.test.ts
+++ b/web/src/components/entry-dialog/useEntryFormFilters.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type GetMySettingsQuery } from "../../graphql/generated/graphql";
+import useEntryFormFilters from "./useEntryFormFilters";
+
+const apolloMocks = vi.hoisted(() => ({
+  useQuery: vi.fn(),
+  useMutation: vi.fn(),
+  useApolloClient: vi.fn(),
+}));
+
+vi.mock("@apollo/client/react", () => ({
+  useQuery: apolloMocks.useQuery,
+  useMutation: apolloMocks.useMutation,
+  useApolloClient: apolloMocks.useApolloClient,
+}));
+
+const buildSettings = (projectsPreset: string[] | null): GetMySettingsQuery => ({
+  getMySettings: {
+    employeeNumber: 1,
+    productPreset: null,
+    activityPreset: null,
+    projectsPreset,
+    jiraNotificationIgnore: null,
+    showWeekend: null,
+    setRemainingHours: null,
+  },
+});
+
+describe("useEntryFormFilters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes the projects preset from settings", async () => {
+    const updateSettings = vi.fn();
+    const client = {
+      readQuery: vi.fn(),
+      writeQuery: vi.fn(),
+    };
+
+    apolloMocks.useQuery.mockReturnValue({ data: buildSettings(["PROJ-1", "PROJ-2"]) });
+    apolloMocks.useMutation.mockReturnValue([updateSettings]);
+    apolloMocks.useApolloClient.mockReturnValue(client);
+
+    const { result } = renderHook(() => useEntryFormFilters());
+
+    await waitFor(() => {
+      expect(result.current.filters.projects).toEqual(["PROJ-1", "PROJ-2"]);
+    });
+
+    expect(result.current.activeFilters).toEqual(["projects"]);
+  });
+
+  it("returns no active filters when there is no preset", async () => {
+    const updateSettings = vi.fn();
+    const client = {
+      readQuery: vi.fn(),
+      writeQuery: vi.fn(),
+    };
+
+    apolloMocks.useQuery.mockReturnValue({ data: buildSettings(null) });
+    apolloMocks.useMutation.mockReturnValue([updateSettings]);
+    apolloMocks.useApolloClient.mockReturnValue(client);
+
+    const { result } = renderHook(() => useEntryFormFilters());
+
+    await waitFor(() => {
+      expect(result.current.filters.projects).toEqual([]);
+    });
+
+    expect(result.current.activeFilters).toEqual([]);
+  });
+
+  it("updates the selected projects through the returned action", async () => {
+    const updateSettings = vi.fn();
+    const client = {
+      readQuery: vi.fn(),
+      writeQuery: vi.fn(),
+    };
+
+    apolloMocks.useQuery.mockReturnValue({ data: buildSettings(["PROJ-1"]) });
+    apolloMocks.useMutation.mockReturnValue([updateSettings]);
+    apolloMocks.useApolloClient.mockReturnValue(client);
+
+    const { result } = renderHook(() => useEntryFormFilters());
+
+    await waitFor(() => {
+      expect(result.current.filters.projects).toEqual(["PROJ-1"]);
+    });
+
+    act(() => {
+      result.current.updateSelectedProjects(["PROJ-3"]);
+    });
+
+    await waitFor(() => {
+      expect(result.current.filters.projects).toEqual(["PROJ-3"]);
+    });
+
+    expect(result.current.activeFilters).toEqual(["projects"]);
+  });
+});

--- a/web/src/components/entry-dialog/useEntryFormFilters.ts
+++ b/web/src/components/entry-dialog/useEntryFormFilters.ts
@@ -2,12 +2,10 @@ import { useQuery, useMutation, useApolloClient } from "@apollo/client/react";
 import { useMemo, useEffect, useRef, useState, useCallback } from "react";
 import { GetMySettingsDocument, UpdateSettingsDocument } from "../../graphql/generated/graphql";
 
-type EntryFormFilters = {
-  projects: string[];
-};
-
 // Add new filter keys with OR ("|")
-type EntryFormFilterKey = "projects";
+export type EntryFormFilterKey = "projects";
+
+type EntryFormFilters = Record<EntryFormFilterKey, string[]>;
 
 type EntryFormFiltersResult = {
   filters: EntryFormFilters;

--- a/web/src/components/entry-dialog/useEntryFormFilters.ts
+++ b/web/src/components/entry-dialog/useEntryFormFilters.ts
@@ -1,0 +1,64 @@
+import { useQuery, useMutation, useApolloClient } from "@apollo/client/react";
+import { useMemo, useEffect, useRef, useState, useCallback } from "react";
+import { GetMySettingsDocument, UpdateSettingsDocument } from "../../graphql/generated/graphql";
+
+type EntryFormFilters = {
+  projects: string[];
+};
+
+// Add new filter keys with OR ("|")
+type EntryFormFilterKey = "projects";
+
+type EntryFormFiltersResult = {
+  filters: EntryFormFilters;
+  activeFilters: EntryFormFilterKey[];
+  updateSelectedProjects: (newProjectKeys: string[]) => void;
+};
+
+export default function useEntryFormFilters(): EntryFormFiltersResult {
+  const { data: settingsData } = useQuery(GetMySettingsDocument);
+  const serverPreset = settingsData?.getMySettings.projectsPreset;
+  const [selectedProjectKeys, setSelectedProjectKeys] = useState<string[]>([]);
+  const initialized = useRef(false);
+  const client = useApolloClient();
+  const [updateSettings] = useMutation(UpdateSettingsDocument, {
+    refetchQueries: [GetMySettingsDocument],
+  });
+
+  useEffect(() => {
+    if (!initialized.current && serverPreset !== undefined) {
+      initialized.current = true;
+      setSelectedProjectKeys(serverPreset ?? []);
+    }
+  }, [serverPreset]);
+
+  const activeFilters = useMemo(() => {
+    const usedFilters: EntryFormFilterKey[] = [];
+
+    if (selectedProjectKeys.length > 0) {
+      usedFilters.push("projects");
+    }
+
+    return usedFilters;
+  }, [selectedProjectKeys]);
+
+  const updateSelectedProjects = useCallback((newProjectKeys: string[]) => {
+    setSelectedProjectKeys(newProjectKeys);
+    const existing = client.readQuery({ query: GetMySettingsDocument });
+    if (existing) {
+      client.writeQuery({
+        query: GetMySettingsDocument,
+        data: { getMySettings: { ...existing.getMySettings, projectsPreset: newProjectKeys } },
+      });
+    }
+    updateSettings({ variables: { settings: { projectsPreset: newProjectKeys } } });
+  }, []);
+
+  return {
+    filters: {
+      projects: selectedProjectKeys,
+    },
+    activeFilters,
+    updateSelectedProjects,
+  };
+}

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1,6 +1,5 @@
 const en = {
   controls: {
-    activeFiltersCount: "",
     aria: {
       prevWeek: "Go to previous week",
       nextWeek: "Go to next week",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1,5 +1,6 @@
 const en = {
   controls: {
+    activeFiltersCount: "",
     aria: {
       prevWeek: "Go to previous week",
       nextWeek: "Go to next week",
@@ -23,7 +24,10 @@ const en = {
     jiraDisconnect: "Disconnect from Jira",
     showWeekend: "Show Weekend",
     hideWeekend: "Hide Weekend",
-    showFilters: "Filters",
+    showFilters: "Show filters",
+    showFilters_aria_zero: "Show filters, no active filters",
+    showFilters_aria_one: "Show filters, 1 active filter",
+    showFilters_aria_other: "Show filters, {{count}} active filters",
     hideFilters: "Hide Filters",
     dateRange: "Date Range",
   },

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -77,8 +77,8 @@ const en = {
     },
     totalHoursToday: "Time on selected day before this entry",
     setRemainingHours: "Set remaining hours automatically",
-    filterProjects: "Projects",
-    filterProjectsHelperText: "Search tickets only from selected projects.",
+    filterProjects: "JIRA projects",
+    filterProjectsHelperText: "Search issues only from selected JIRA projects.",
   },
   entryTable: {
     accepted: "Accepted",

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -28,7 +28,7 @@ const en = {
     showFilters_aria_zero: "Show filters, no active filters",
     showFilters_aria_one: "Show filters, 1 active filter",
     showFilters_aria_other: "Show filters, {{count}} active filters",
-    hideFilters: "Hide Filters",
+    hideFilters: "Hide filters",
     dateRange: "Date Range",
   },
   dimensionNames: {
@@ -75,7 +75,8 @@ const en = {
     },
     totalHoursToday: "Time on selected day before this entry",
     setRemainingHours: "Set remaining hours automatically",
-    filterProjects: "Filter Projects",
+    filterProjects: "Projects",
+    filterProjectsHelperText: "Search tickets only from selected projects.",
   },
   entryTable: {
     accepted: "Accepted",

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -1,5 +1,6 @@
 const fi = {
   controls: {
+    activeFiltersCount: "{{count}} aktiivista filtteriä",
     aria: {
       prevWeek: "Näytä edellinen viikko",
       nextWeek: "Näytä seuraava viikko",
@@ -23,7 +24,10 @@ const fi = {
     jiraDisconnect: "Katkaise Jira-yhteys",
     showWeekend: "Näytä Viikonloppu",
     hideWeekend: "Piilota Viikonloppu",
-    showFilters: "Suodattimet",
+    showFilters: "Näytä suodattimet",
+    showFilters_aria_zero: "Näytä suodattimet, ei aktiivisia suodattimia",
+    showFilters_aria_one: "Näytä suodattimet, 1 aktiivinen suodatin",
+    showFilters_aria_other: "Näytä suodattimet, {{count}} aktiivista suodatinta",
     hideFilters: "Piilota Suodattimet",
     dateRange: "Aikaväli",
   },

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -77,8 +77,8 @@ const fi = {
     },
     totalHoursToday: "Päivän työaika ennen tätä kirjausta",
     setRemainingHours: "Aseta jäljellä olevat tunnit automaattisesti",
-    filterProjects: "Projektit",
-    filterProjectsHelperText: "Hae tikettejä vain valituista projekteista.",
+    filterProjects: "JIRA-projektit",
+    filterProjectsHelperText: "Hae tikettejä vain valituista JIRA-projekteista.",
   },
   entryTable: {
     accepted: "Hyväksytty",

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -1,6 +1,5 @@
 const fi = {
   controls: {
-    activeFiltersCount: "{{count}} aktiivista filtteriä",
     aria: {
       prevWeek: "Näytä edellinen viikko",
       nextWeek: "Näytä seuraava viikko",

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -28,7 +28,7 @@ const fi = {
     showFilters_aria_zero: "Näytä suodattimet, ei aktiivisia suodattimia",
     showFilters_aria_one: "Näytä suodattimet, 1 aktiivinen suodatin",
     showFilters_aria_other: "Näytä suodattimet, {{count}} aktiivista suodatinta",
-    hideFilters: "Piilota Suodattimet",
+    hideFilters: "Piilota suodattimet",
     dateRange: "Aikaväli",
   },
   dimensionNames: {
@@ -75,7 +75,8 @@ const fi = {
     },
     totalHoursToday: "Päivän työaika ennen tätä kirjausta",
     setRemainingHours: "Aseta jäljellä olevat tunnit automaattisesti",
-    filterProjects: "Suodata Projektit",
+    filterProjects: "Projektit",
+    filterProjectsHelperText: "Hae tikettejä vain valituista projekteista.",
   },
   entryTable: {
     accepted: "Hyväksytty",


### PR DESCRIPTION
KEIJO-171

- Moved filtering section inside EntryForm into its own component `EntryFiltersSection`
- Created a custom hook `useEntryFormFilters` that contains the form filters management
- Added a badge for the active filters count (only shown when there are active filters)
- Changed filtering section visibility toggle buttons color for better visibility/accessibility
- Added a helper text to explain the purpose of the filter
- Changed toggle button text and aria label
  
### Developer's checklist
- [x] I wrote unit tests for relevant components
- [ ] I created tickets for testing needs found during this PR that are outside the scope of this ticket

## Screenshots

<details>
<summary>Dark mode</summary>

With active filters:
<img width="898" height="503" alt="Screenshot 2026-06-22 at 15 28 55" src="https://github.com/user-attachments/assets/086a412a-c774-48d3-8dbf-dfbac5ca6229" />
<img width="898" height="581" alt="Screenshot 2026-06-22 at 15 28 47" src="https://github.com/user-attachments/assets/08e33ed3-fa97-4720-8a15-c31666ae7031" />

Without active filters:
<img width="409" height="88" alt="Screenshot 2026-06-22 at 15 29 14" src="https://github.com/user-attachments/assets/c2343cf5-d0cd-4963-837f-10555f73bdd5" />
<img width="408" height="140" alt="Screenshot 2026-06-22 at 15 29 06" src="https://github.com/user-attachments/assets/03520c11-a76f-4cb5-95c7-9e0949caa54f" />
</details>

<details>
<summary>Light mode</summary>

With active filters:
<img width="901" height="578" alt="Screenshot 2026-06-22 at 15 28 11" src="https://github.com/user-attachments/assets/4f51ccc6-08e3-497e-afba-e89641f135fa" />
<img width="896" height="518" alt="Screenshot 2026-06-22 at 15 27 55" src="https://github.com/user-attachments/assets/5d279b64-e794-4be4-8221-952aecf989a0" />

Without active filters:
<img width="399" height="69" alt="Screenshot 2026-06-22 at 15 28 27" src="https://github.com/user-attachments/assets/6fab17c6-65e6-4312-8a4b-cc59bea05679" />
<img width="415" height="135" alt="Screenshot 2026-06-22 at 15 28 21" src="https://github.com/user-attachments/assets/a8704fa3-6458-48db-a1ed-72b79cce5143" />
</details>

