### PR TITLE
[improvement]: Show in UI when running dev server

### DIFF
--- a/web/src/components/layout/AppBar.tsx
+++ b/web/src/components/layout/AppBar.tsx
@@ -14,7 +14,11 @@ const AppBar = () => {
   const mobile = useMediaQuery(theme.breakpoints.down("md"));
 
   return (
-    <MuiAppBar position="sticky" sx={{ mb: 4 }}>
+    <MuiAppBar
+      position="sticky"
+      sx={{ mb: 4 }}
+      {...(import.meta.env.DEV && { color: "error", enableColorOnDark: true })}
+    >
       <Toolbar sx={{ gap: 2 }}>
         <KeijoLogo />
         <Title />

--- a/web/src/components/layout/Title.tsx
+++ b/web/src/components/layout/Title.tsx
@@ -1,9 +1,11 @@
-import { Typography } from "@mui/material";
+import Typography from "@mui/material/Typography";
 import { useEffect } from "react";
 import useTitle from "./useTitle";
+import { useTranslation } from "react-i18next";
 
 const Title = () => {
   const { title } = useTitle();
+  const { t } = useTranslation();
 
   useEffect(() => {
     window.document.title = title ? `${title} | Keijo` : "Keijo";
@@ -12,6 +14,7 @@ const Title = () => {
   return (
     <Typography variant="h6" sx={{ flexGrow: 1, overflow: "hidden", textOverflow: "ellipsis" }}>
       {title}
+      {import.meta.env.DEV && " - " + t("environment.development").toUpperCase()}
     </Typography>
   );
 };

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -33,6 +33,9 @@ const en = {
     issue: "Issue",
     client: "Client",
   },
+  environment: {
+    development: "Development",
+  },
   errors: {
     error: "Error",
     missingEmployeeNumber:

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -33,6 +33,9 @@ const fi = {
     issue: "Tiketti",
     client: "Asiakas",
   },
+  environment: {
+    development: "Kehitys",
+  },
   errors: {
     error: "Virhe",
     missingEmployeeNumber:


### PR DESCRIPTION
KEIJO-151

Changed AppBar color and added text "DEVELOPMENT" whenever the React frontend is running in dev server (running commands `vite`, `vite dev` or `vite serve`). Note: this won't show in a production-like development environment, ie. when `import.meta.env.PROD` is `true` (so a shared sandbox or development, or staging environment). 
  
### Developer's checklist
- [ ] I wrote unit tests for relevant components
- [ ] I created tickets for testing needs found during this PR that are outside the scope of this ticket

## Screenshots

<img width="863" height="998" alt="Screenshot 2026-06-23 at 10 45 51" src="https://github.com/user-attachments/assets/616104f3-0965-4760-a102-15fa63c31b2a" />
<img width="864" height="999" alt="Screenshot 2026-06-23 at 10 45 38" src="https://github.com/user-attachments/assets/f21e6155-4b93-4c8e-b42f-a476821c286e" />
