### PR TITLE
[WorkdaySummary]: Enhance semantics

### DIFF
--- a/e2e/fixtures/entry-browser/entry-browser.ts
+++ b/e2e/fixtures/entry-browser/entry-browser.ts
@@ -12,4 +12,16 @@ export class EntryBrowser {
       this.t("controls.addEntryWithDate", { date, interpolation: { escapeValue: false } }),
     );
   }
+
+  private escapeRegex(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  }
+
+  getAccordionAddEntryButton() {
+    // "Add New Entry on {{date}}" -> match the localized prefix + a date digit
+    const withDatePrefix = this.t("controls.addEntryWithDate", { date: "" }).trim();
+    return this.page.getByRole("button", {
+      name: new RegExp(`^${this.escapeRegex(withDatePrefix)}\\s*\\d`),
+    });
+  }
 }

--- a/e2e/tests/entry.desktop.spec.ts
+++ b/e2e/tests/entry.desktop.spec.ts
@@ -59,12 +59,8 @@ test.describe("Add entry", () => {
     await expect(page.getByRole("alert")).toContainText(t("notifications.addEntry.success"));
   });
 
-  test("Should add entry from entry row", async ({ page, t }) => {
-    await page
-      .getByRole("button")
-      .getByRole("button", { name: t("entryDialog.title.create") })
-      .first()
-      .click();
+  test("Should add entry from entry row", async ({ entryBrowser, page, t }) => {
+    await entryBrowser.getAccordionAddEntryButton().first().click();
     await expect(page).toHaveURL(/.*\/create$/);
     await fillEntryForm(page, t, entries[0]);
     await page.getByRole("button", { name: t("entryDialog.submit") }).click();
@@ -114,13 +110,9 @@ test.describe("Delete entry", () => {
 });
 
 test.describe("Entry defaults", () => {
-  test("Should set remaining hours when enabled", async ({ page, t }) => {
+  test("Should set remaining hours when enabled", async ({ entryBrowser, page, t }) => {
     await page.goto(emptyWeekUrl);
-    await page
-      .getByRole("button")
-      .getByRole("button", { name: t("entryDialog.title.create") })
-      .first()
-      .click();
+    await entryBrowser.getAccordionAddEntryButton().first().click();
     await expect(page.getByRole("group", { name: t("entryDialog.duration") })).toContainText(
       "00:00",
     );

--- a/e2e/tests/entry.mobile.spec.ts
+++ b/e2e/tests/entry.mobile.spec.ts
@@ -57,12 +57,8 @@ test.describe("Add entry mobile", () => {
     await expect(page.getByRole("alert")).toContainText(t("notifications.addEntry.success"));
   });
 
-  test("Should add entry from entry row", async ({ page, t }) => {
-    await page
-      .getByRole("button")
-      .getByRole("button", { name: t("entryDialog.title.create") })
-      .first()
-      .click();
+  test("Should add entry from entry row", async ({ entryBrowser, page, t }) => {
+    await entryBrowser.getAccordionAddEntryButton().first().click();
     await expect(page).toHaveURL(/.*\/create$/);
     await fillEntryFormMobile(page, t, entries[0]);
     await page.getByRole("button", { name: t("entryDialog.submit") }).click();
@@ -113,13 +109,9 @@ test.describe("Delete entry mobile", () => {
 });
 
 test.describe("Entry defaults mobile", () => {
-  test("Should set remaining hours when enabled", async ({ page, t }) => {
+  test("Should set remaining hours when enabled", async ({ entryBrowser, page, t }) => {
     await page.goto(emptyWeekUrl);
-    await page
-      .getByRole("button")
-      .getByRole("button", { name: t("entryDialog.title.create") })
-      .first()
-      .click();
+    await entryBrowser.getAccordionAddEntryButton().first().click();
     await expect(page.getByRole("group", { name: t("entryDialog.duration") })).toContainText(
       "00:00",
     );

--- a/e2e/tests/page.desktop.spec.ts
+++ b/e2e/tests/page.desktop.spec.ts
@@ -3,6 +3,7 @@ import { Dayjs } from "dayjs";
 import { TFunction } from "i18next";
 import { getMockEntries } from "mock-data";
 import { test } from "../fixtures/fixtures";
+import { escapeRegex, formatHours } from "./utils/mockEntryHelpers";
 
 const mockEntries = getMockEntries();
 const testDate = "2024-05-13";
@@ -29,25 +30,30 @@ test.describe("Landing page", () => {
   });
 
   test("Should have correct mock entries", async ({ page, dayjs }) => {
-    for (const entry of mockEntries) {
-      const date = dayjs(entry.date);
-      await page.goto(mockEntryWeekUrl);
-      const workdayEntryList = page
-        .locator("div", {
-          has: page.getByRole("button", { name: date.format("dd l") }),
-        })
-        .last()
-        .getByRole("list");
+    await page.goto(mockEntryWeekUrl);
 
-      const hour = Math.floor(Number(entry.hours));
-      const minute = (Number(entry.hours) * 60) % 60;
-      let entryRows = workdayEntryList.getByRole("listitem");
-      // Filter row by field texts
-      for (const field of entry.fields) {
-        entryRows = entryRows.filter({ hasText: new RegExp(`${field.DimensionItem}`) });
+    const dayLabels = [...new Set(mockEntries.map((e) => dayjs(e.date).format("dd l")))];
+    for (const dayLabel of dayLabels) {
+      const dayButton = page.getByRole("button", {
+        name: new RegExp(`^${escapeRegex(dayLabel)}\\b`),
+      });
+      if ((await dayButton.getAttribute("aria-expanded")) !== "true") {
+        await dayButton.click();
       }
-      entryRows = entryRows.filter({ hasText: new RegExp(`${hour}:${minute}`) });
-      await expect(entryRows.first()).toBeVisible();
+    }
+
+    const rowTexts = await page.getByRole("listitem").allTextContents();
+
+    for (const entry of mockEntries) {
+      const expectedTime = formatHours(entry.hours);
+      const dimensions = entry.fields.map((f) => f.DimensionItem);
+
+      const matchFound = rowTexts.some((text) => {
+        if (!text.includes(expectedTime)) return false;
+        return dimensions.every((d) => text.includes(d));
+      });
+
+      expect(matchFound).toBeTruthy();
     }
   });
 

--- a/e2e/tests/page.mobile.spec.ts
+++ b/e2e/tests/page.mobile.spec.ts
@@ -3,6 +3,7 @@ import { Dayjs } from "dayjs";
 import { TFunction } from "i18next";
 import { getMockEntries } from "mock-data";
 import { test } from "../fixtures/fixtures";
+import { escapeRegex, formatHours } from "./utils/mockEntryHelpers";
 
 const mockEntries = getMockEntries();
 const testDate = "2024-05-13";
@@ -29,24 +30,32 @@ test.describe("Landing page mobile", () => {
   });
 
   test("Should have mock entries", async ({ page, dayjs }) => {
-    for (const entry of mockEntries) {
-      const date = dayjs(entry.date);
-      await page.goto(mockEntryWeekUrl);
-      const workdayEntryList = page
-        .locator("div", {
-          has: page.getByRole("button", { name: date.format("dd l") }),
-        })
-        .last()
-        .getByRole("list");
-      const hour = Math.floor(Number(entry.hours));
-      const minute = (Number(entry.hours) * 60) % 60;
-      let entryRows = workdayEntryList.getByRole("listitem");
-      // Filter row by field texts
-      for (const field of entry.fields) {
-        entryRows = entryRows.filter({ hasText: new RegExp(`${field.DimensionItem}`) });
+    await page.goto(mockEntryWeekUrl);
+
+    // Expand all days that are expected to have entries.
+    const dayLabels = [...new Set(mockEntries.map((e) => dayjs(e.date).format("dd l")))];
+    for (const dayLabel of dayLabels) {
+      const dayButton = page.getByRole("button", {
+        name: new RegExp(`^${escapeRegex(dayLabel)}\\b`),
+      });
+      if ((await dayButton.getAttribute("aria-expanded")) !== "true") {
+        await dayButton.click();
       }
-      entryRows = entryRows.filter({ hasText: new RegExp(`${hour}:${minute}`) });
-      await expect(entryRows.first()).toBeVisible();
+    }
+
+    // Read visible row texts once, then assert each mock entry exists.
+    const rowTexts = await page.getByRole("listitem").allTextContents();
+
+    for (const entry of mockEntries) {
+      const expectedTime = formatHours(entry.hours);
+      const dimensions = entry.fields.map((f) => f.DimensionItem);
+
+      const matchFound = rowTexts.some((text) => {
+        if (!text.includes(expectedTime)) return false;
+        return dimensions.every((d) => text.includes(d));
+      });
+
+      expect(matchFound).toBeTruthy();
     }
   });
 

--- a/e2e/tests/utils/mockEntryHelpers.ts
+++ b/e2e/tests/utils/mockEntryHelpers.ts
@@ -1,0 +1,8 @@
+export const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const formatHours = (hours: string) => {
+  const totalMinutes = Math.round(Number(hours) * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = String(totalMinutes % 60).padStart(2, "0");
+  return `${h}:${m}`;
+};

--- a/web/src/components/entry-dialog/DurationSlider.tsx
+++ b/web/src/components/entry-dialog/DurationSlider.tsx
@@ -62,6 +62,7 @@ const DurationSlider = ({ field }: DurationSliderProps) => {
         }}
       />
       <Slider
+        aria-label={t("entryDialog.duration")}
         min={0}
         max={600}
         step={15}

--- a/web/src/components/layout/ContentContainer.tsx
+++ b/web/src/components/layout/ContentContainer.tsx
@@ -4,7 +4,7 @@ import Footer from "./Footer";
 
 const ContentContainer = ({ children }: ChildrenProps) => (
   <>
-    <Container>{children}</Container>
+    <Container role="main">{children}</Container>
     <Box component="footer" sx={{ display: "flex", justifyContent: "center", mt: 8, mb: 3 }}>
       <Footer />
     </Box>

--- a/web/src/components/layout/ContentContainer.tsx
+++ b/web/src/components/layout/ContentContainer.tsx
@@ -1,22 +1,12 @@
-import { Box, Container, Typography } from "@mui/material";
+import { Box, Container } from "@mui/material";
 import { ChildrenProps } from "../../common/types";
 import Footer from "./Footer";
 
 const ContentContainer = ({ children }: ChildrenProps) => (
   <>
     <Container>{children}</Container>
-    <Box sx={{ display: "flex", justifyContent: "center", mt: 8, mb: 3 }}>
-      <Typography
-        sx={{
-          color: (theme) =>
-            theme.palette.mode === "dark" ? theme.palette.grey[400] : theme.palette.grey[900],
-          fontSize: "0.8rem",
-          wordSpacing: 2,
-          fontWeight: 100,
-        }}
-      >
-        <Footer />
-      </Typography>
+    <Box component="footer" sx={{ display: "flex", justifyContent: "center", mt: 8, mb: 3 }}>
+      <Footer />
     </Box>
   </>
 );

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -2,7 +2,14 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 
 const Footer = () => (
-  <Stack direction="column" sx={{ color: "text.secondary" }}>
+  <Stack
+    direction="column"
+    sx={{
+      color: (theme) =>
+        theme.palette.mode === "dark" ? theme.palette.grey[400] : theme.palette.grey[900],
+      wordSpacing: 2,
+    }}
+  >
     <Typography component="span" variant="overline" align="center">
       Keijo {import.meta.env.APP_VERSION}
     </Typography>

--- a/web/src/components/layout/Title.tsx
+++ b/web/src/components/layout/Title.tsx
@@ -10,7 +10,11 @@ const Title = () => {
   }, [title]);
 
   return (
-    <Typography variant="h6" sx={{ flexGrow: 1, overflow: "hidden", textOverflow: "ellipsis" }}>
+    <Typography
+      component="h1"
+      variant="h6"
+      sx={{ flexGrow: 1, overflow: "hidden", textOverflow: "ellipsis" }}
+    >
       {title}
     </Typography>
   );

--- a/web/src/components/workday-accordion/WorkdaySummary.tsx
+++ b/web/src/components/workday-accordion/WorkdaySummary.tsx
@@ -69,41 +69,47 @@ const WorkdaySummary = ({ workday }: WorkdayAccordionProps) => {
   };
 
   return (
-    <AccordionSummary expandIcon={!disabled && <ExpandMoreIcon />}>
-      <Box
-        sx={{
-          display: "flex",
-          flexGrow: 1,
-          justifyContent: "space-between",
-          alignItems: "center",
-        }}
-      >
+    <Box sx={{ position: "relative" }}>
+      <AccordionSummary expandIcon={!disabled && <ExpandMoreIcon />}>
         <Box
-          sx={
-            disabled ? { display: "flex", flexDirection: "row", alignItems: "center", gap: 2 } : {}
-          }
+          sx={{
+            display: "flex",
+            flexGrow: 1,
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
         >
-          <Typography sx={{ textTransform: "capitalize", minWidth: 105 }}>
-            {date.format("dd l")}
-          </Typography>
-          {mobile && (
-            <Box sx={!disabled ? { mt: 1 } : {}}>
-              <InfoChip />
-            </Box>
-          )}
-        </Box>
-        {!mobile && <InfoChip />}
-        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Box
+            sx={
+              disabled
+                ? { display: "flex", flexDirection: "row", alignItems: "center", gap: 2 }
+                : {}
+            }
+          >
+            <Typography sx={{ textTransform: "capitalize", minWidth: 105 }}>
+              {date.format("dd l")}
+            </Typography>
+            {mobile && (
+              <Box sx={!disabled ? { mt: 1 } : {}}>
+                <InfoChip />
+              </Box>
+            )}
+          </Box>
+          {!mobile && <InfoChip />}
           {!disabled && (
-            <>
-              <EntryDialogButton date={date} size="medium" />
-              <Chip label={`${totalHoursFormatted} h`} sx={{ mr: 2, color: "inherit" }} />
-            </>
+            <Chip label={`${totalHoursFormatted} h`} sx={{ mr: 2, color: "inherit" }} />
           )}
           {disabled && !mobile && <Box sx={{ width: 133 }} />}
         </Box>
-      </Box>
-    </AccordionSummary>
+      </AccordionSummary>
+      {!disabled && (
+        <Box
+          sx={{ position: "absolute", top: "50%", transform: "translateY(-50%)", right: "116px" }}
+        >
+          <EntryDialogButton date={date} size="medium" />
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/web/src/components/workday-accordion/entry-row/DesktopEntryRow.tsx
+++ b/web/src/components/workday-accordion/entry-row/DesktopEntryRow.tsx
@@ -61,7 +61,9 @@ const DesktopEntryRow = ({ entry, date }: EntryRowProps) => {
             mr: 1,
           }}
         >
-          <Typography variant="h6">{roundedDuration.format("H:mm")}</Typography>
+          <Typography component="h4" variant="h6">
+            {roundedDuration.format("H:mm")}
+          </Typography>
         </Box>
         {product && <DimensionChip dimension="product" label={product} />}
         {activity && <DimensionChip dimension="activity" label={activity} />}
@@ -69,6 +71,7 @@ const DesktopEntryRow = ({ entry, date }: EntryRowProps) => {
         {client && <DimensionChip dimension="client" label={client} />}
         {(paid || open || accepted) && !product && !activity && !issue && !client && typeName && (
           <Typography
+            component="h5"
             variant="subtitle1"
             sx={{ overflow: { xs: "visible", md: "hidden" }, textOverflow: "ellipsis" }}
           >
@@ -77,6 +80,7 @@ const DesktopEntryRow = ({ entry, date }: EntryRowProps) => {
         )}
         {description && (
           <Typography
+            component="h5"
             variant="subtitle2"
             sx={{ overflow: { xs: "visible", md: "hidden" }, textOverflow: "ellipsis" }}
           >

--- a/web/src/components/workday-browser/WeekControl.tsx
+++ b/web/src/components/workday-browser/WeekControl.tsx
@@ -89,8 +89,11 @@ const WeekControl = () => {
                   borderBottom: week.no === currentWeek ? "1px solid grey" : null,
                 }}
               >
-                <Typography variant="h5">{week.no}</Typography>
+                <Typography component="h2" variant="h5">
+                  {week.no}
+                </Typography>
                 <Typography
+                  component="h3"
                   variant="subtitle2"
                   sx={{ alignSelf: "end", mb: "3px", ml: 1, fontStyle: "italic" }}
                 >


### PR DESCRIPTION
KEIJO-156

There were some semantic problems e.g. in nested components which caused console errors.
- Moved `EntryDialogButton` outside of `AccordionSummary` -> `button` was a descendant of another `button`
- Removed unnecessary `Typography` component from `ContentContainer` -> `div` was a descendant of a `p`
  - Added the necessary styles straight to the `Footer`
- Added `footer` and `main` landmarks
- Added missing `h1` and fixed heading level orders
- Fixed e2e tests
  - `page.desktop/mobile.spec.ts` were a struggle. In the end Copilot fixed the problem, which probably was this unstable selector `const workdayEntryList = page.locator("div", { has: page.getByRole("button", { name: date.format("dd l") }), }).last().getByRole("list");` but in the end the whole test got re-written to finally get it to pass.
  
### Developer's checklist
- [ ] I wrote unit tests for relevant components
- [ ] I created tickets for testing needs found during this PR that are outside the scope of this ticket
