### PR TITLE
[JiraIssueComboBox]: Improve issue Autocomplete value handling

### DIFF
--- a/web/src/components/entry-dialog/DimensionComboBox.tsx
+++ b/web/src/components/entry-dialog/DimensionComboBox.tsx
@@ -83,6 +83,7 @@ const DimensionComboBox = <T extends FieldValues>({
                   helperText={form.formState.errors[name]?.message as string}
                 />
               )}
+              clearText={t("entryDialog.input.clear")}
               filterOptions={(options, state) =>
                 inputFilter(name === "issue" ? extFilter(options) : options, state)
               }

--- a/web/src/components/entry-dialog/JiraIssueComboBox.test.tsx
+++ b/web/src/components/entry-dialog/JiraIssueComboBox.test.tsx
@@ -157,8 +157,12 @@ describe("JiraIssueComboBox", () => {
 
     const option = await screen.findByRole("option", { name: "ABC-1: Test issue" });
     fireEvent.click(option);
+    input.focus();
 
-    const clearButton = screen.getByLabelText("Clear");
+    const clearButton = await screen.findByRole("button", {
+      name: "entryDialog.input.clear",
+      hidden: true,
+    });
     fireEvent.click(clearButton);
 
     expect(input.value).toBe("");

--- a/web/src/components/entry-dialog/JiraIssueComboBox.test.tsx
+++ b/web/src/components/entry-dialog/JiraIssueComboBox.test.tsx
@@ -44,7 +44,7 @@ vi.mock("../../jira/useJiraIssueKeySearch", () => ({
 }));
 
 type TestFormValues = {
-  issue: string;
+  issue: string | null;
 };
 
 const issue = {
@@ -52,8 +52,14 @@ const issue = {
   fields: { summary: "Test issue" },
 };
 
-const TestForm = ({ onSubmit }: { onSubmit: (values: TestFormValues) => void }) => {
-  const form = useForm<TestFormValues>({ defaultValues: { issue: "" } });
+const TestForm = ({
+  onSubmit,
+  defaultIssue = "",
+}: {
+  onSubmit: (values: TestFormValues) => void;
+  defaultIssue?: string | null;
+}) => {
+  const form = useForm<TestFormValues>({ defaultValues: { issue: defaultIssue } });
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -87,6 +93,7 @@ describe("JiraIssueComboBox", () => {
 
     const option = await screen.findByRole("option", { name: "ABC-1: Test issue" });
     fireEvent.click(option);
+    expect(input.value).toBe("ABC-1: Test issue");
 
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -125,5 +132,35 @@ describe("JiraIssueComboBox", () => {
     });
 
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows prefilled issue in input when editing existing workday entry", async () => {
+    const onSubmit = vi.fn();
+
+    render(<TestForm onSubmit={onSubmit} defaultIssue="ABC-1" />);
+
+    const input = screen.getByLabelText("Issue") as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(input.value === "ABC-1" || input.value === "ABC-1: Test issue").toBeTruthy();
+    });
+  });
+
+  it("clears input when the clear button is clicked", async () => {
+    const onSubmit = vi.fn();
+
+    render(<TestForm onSubmit={onSubmit} />);
+
+    const input = screen.getByLabelText("Issue") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "ABC-1" } });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    const option = await screen.findByRole("option", { name: "ABC-1: Test issue" });
+    fireEvent.click(option);
+
+    const clearButton = screen.getByLabelText("Clear");
+    fireEvent.click(clearButton);
+
+    expect(input.value).toBe("");
   });
 });

--- a/web/src/components/entry-dialog/JiraIssueComboBox.tsx
+++ b/web/src/components/entry-dialog/JiraIssueComboBox.tsx
@@ -136,6 +136,7 @@ const JiraIssueComboBox = <T extends FieldValues>({
                     }
                   : undefined
               }
+              clearText={t("entryDialog.input.clear")}
               filterOptions={() => options}
             />
           )}

--- a/web/src/components/entry-dialog/JiraIssueComboBox.tsx
+++ b/web/src/components/entry-dialog/JiraIssueComboBox.tsx
@@ -3,10 +3,11 @@ import { Control, ControllerProps, FieldValues, UseFormReturn, Controller } from
 import { useDebounceValue } from "usehooks-ts";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
-import Autocomplete from "@mui/material/Autocomplete";
+import Autocomplete, { type AutocompleteInputChangeReason } from "@mui/material/Autocomplete";
 import FormControl from "@mui/material/FormControl";
 import useJiraIssueOptions, { type Option } from "./useJiraIssueOptions";
 import { useTranslation } from "react-i18next";
+import { useState } from "react";
 
 type JiraIssueComboBoxProps<T extends FieldValues> = {
   form: UseFormReturn<T>;
@@ -22,21 +23,20 @@ const JiraIssueComboBox = <T extends FieldValues>({
   rules,
 }: JiraIssueComboBoxProps<T>) => {
   const { t } = useTranslation();
+
   // Debounce search term to avoid firing queries on every key press.
   const [searchTerm, setSearchTerm] = useDebounceValue("", 300);
+  const [inputValue, setInputValue] = useState("");
 
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const { options } = useJiraIssueOptions(searchTerm);
 
-  // Validation for 'issue' field
-  // Make sure the selected value exists in the options and convert value to string
   const validateIssue = (value: string | null | Option) => {
     if (!value) return true;
-    const exists = options.some((option) =>
-      typeof option === "string" ? option === value : option.value === value,
-    );
+    const normalizedValue = typeof value === "string" ? value : value.value;
+    const exists = options.some((option) => option.value === normalizedValue);
     return exists ? true : t("entryDialog.validation.issueInOptions");
   };
 
@@ -60,16 +60,29 @@ const JiraIssueComboBox = <T extends FieldValues>({
               freeSolo
               forcePopupIcon
               value={value ?? ""}
+              inputValue={inputValue}
               onChange={(_, selectedOption) => {
-                if (selectedOption == null || typeof selectedOption === "string") {
+                if (selectedOption == null) {
+                  onChange(null);
+                  setInputValue("");
+                } else if (typeof selectedOption === "string") {
                   onChange(selectedOption);
+                  setInputValue(selectedOption);
                 } else {
                   onChange(selectedOption.value);
+                  setInputValue(selectedOption.label);
                 }
               }}
-              onInputChange={(_, value) => {
-                onChange(value);
-                setSearchTerm(value);
+              onInputChange={(_, value, reason: AutocompleteInputChangeReason) => {
+                if (reason === "input") {
+                  setSearchTerm(value);
+                  setInputValue(value);
+                  onChange(value);
+                } else if (reason === "clear") {
+                  setSearchTerm("");
+                  setInputValue("");
+                  onChange(null);
+                }
               }}
               renderInput={(params) => (
                 <TextField
@@ -80,6 +93,7 @@ const JiraIssueComboBox = <T extends FieldValues>({
                 />
               )}
               options={options}
+              getOptionLabel={(option) => (typeof option === "string" ? option : option.label)}
               getOptionDisabled={(option) => option.disabled}
               renderOption={(props, option) => {
                 const { key, ...rest } = props;

--- a/web/src/components/entry-dialog/JiraIssueComboBox.tsx
+++ b/web/src/components/entry-dialog/JiraIssueComboBox.tsx
@@ -1,5 +1,12 @@
 import { ListItem, ListItemText, useMediaQuery, useTheme } from "@mui/material";
-import { Control, ControllerProps, FieldValues, UseFormReturn, Controller } from "react-hook-form";
+import {
+  Control,
+  ControllerProps,
+  FieldValues,
+  UseFormReturn,
+  Controller,
+  Path,
+} from "react-hook-form";
 import { useDebounceValue } from "usehooks-ts";
 import Grid from "@mui/material/Grid";
 import TextField from "@mui/material/TextField";
@@ -7,7 +14,7 @@ import Autocomplete, { type AutocompleteInputChangeReason } from "@mui/material/
 import FormControl from "@mui/material/FormControl";
 import useJiraIssueOptions, { type Option } from "./useJiraIssueOptions";
 import { useTranslation } from "react-i18next";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 type JiraIssueComboBoxProps<T extends FieldValues> = {
   form: UseFormReturn<T>;
@@ -32,6 +39,18 @@ const JiraIssueComboBox = <T extends FieldValues>({
   const mobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const { options } = useJiraIssueOptions(searchTerm);
+
+  useEffect(() => {
+    const currentIssue = form.getValues(name as Path<T>) as string | null;
+
+    if (!currentIssue) {
+      setInputValue("");
+      return;
+    }
+
+    const matched = options.find((option) => option.value === currentIssue);
+    setInputValue(matched ? matched.label : currentIssue);
+  }, [form, name, options]);
 
   const validateIssue = (value: string | null | Option) => {
     if (!value) return true;

--- a/web/src/components/entry-dialog/ProjectFilter.tsx
+++ b/web/src/components/entry-dialog/ProjectFilter.tsx
@@ -46,6 +46,7 @@ export default function ProjectFilter({ selectedProjects, onProjectsChange }: Pr
         }}
         multiple
         renderInput={(params) => <TextField {...params} label={t("entryDialog.filterProjects")} />}
+        clearText={t("entryDialog.input.clear")}
         aria-describedby={helperId}
       />
       <FormHelperText id={helperId}>{t("entryDialog.filterProjectsHelperText")}</FormHelperText>

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -68,6 +68,9 @@ const en = {
       "You are editing an existing entry. Note that this entry will move to the end of the list. This is due to Netvisor API not supporting actually editing entries, rather the old entry will be deleted and a new one created in its place.",
     openStatusNote:
       "This entry has been left with an open acceptance status in Netvisor. You can either save the entry as is with Keijo or switch to Netvisor and update the status there.",
+    input: {
+      clear: "Clear selection",
+    },
     validation: {
       productRequired: "Product is required",
       activityRequired: "Function is required",

--- a/web/src/i18n/fi.ts
+++ b/web/src/i18n/fi.ts
@@ -68,6 +68,9 @@ const fi = {
       "Olet muokkaamassa olemassa olevaa kirjausta. Huomaa, että muokattu kirjaus tulee siirtymään listan viimeiseksi. Tämä johtuu siitä, että Netvisor API ei tue kirjauksen muokkaamista, vaan pellin alla vanha poistetaan ja sen tilalle luodaan uusi kirjaus.",
     openStatusNote:
       "Tämä kirjaus on jätetty Netvisorissa avoimeen tilaan. Voit muuttaa sen kuitatuksi Keijossa tallentamalla kirjauksen sellaisenaan tai vaihtoehtoisesti käydä päivittämässä tilan Netvisorin kautta.",
+    input: {
+      clear: "Tyhjennä valinta",
+    },
     validation: {
       productRequired: "Tuote on pakollinen tieto.",
       activityRequired: "Toiminto on pakollinen tieto.",


### PR DESCRIPTION
KEIJO-188

- Separated the display text from the stored key value
  - The form still uses the issue key, but the input shows the full issue summary (`option.label`)
- Added the input text handling via `inputValue` state
  - `useEffect` is necessary for keeping the existing (and matched to options) issue visible when editing entry
- Updated `onInputChange` to fire only when user types or clears the input with `AutocompleteInputChangeReason`
- Added translations for entry dialog fields with clear button
  
### Developer's checklist
- [x] I wrote unit tests for relevant components
- [ ] I created tickets for testing needs found during this PR that are outside the scope of this ticket
